### PR TITLE
chore: release 0.1.1 (validate tokenless publish)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mindot/will",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Will — an engine for persistent machine minds. A Will is a continuously-ticking synthetic mind built from 38 cognitive faculties, a learning agency pipeline, and a dual-process executive — deterministic, persistent, and portable (PMA).",
   "author": "Fabrice <fabrice8@github.com>",
   "license": "Apache-2.0",


### PR DESCRIPTION
Patch bump `0.1.0` → `0.1.1`. No source changes — this exists to **validate the tokenless publish pipeline end-to-end** (first publish via npm trusted publishing / OIDC after #14).

After merge, cutting the `v0.1.1` GitHub Release triggers `publish.yml`, which should authenticate purely via GitHub OIDC (no `NPM_TOKEN` — it's been deleted) and attach provenance automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)