### PR TITLE
feat(agency): rich effector declarations — per-ability meaning + priors (Phase 2)

### DIFF
--- a/.TODO/CUSTOM_ABILITY_WIRING.md
+++ b/.TODO/CUSTOM_ABILITY_WIRING.md
@@ -48,10 +48,18 @@ feeds the agency learning loop like any other action.
   let `attack`/`give`/`trade` target a *specific* perceived entity, generalise
   the entity-binding pass to bind N entity-binding schemas, and let an effector
   declare `binds: 'entity'`.
-- **Per-effector metadata.** Effectors are flat strings → uniform cost (0.15),
-  no preconditions, no affective prior. Let a profile declare an effector as an
-  object (`{ name, cost?, binds?, preconditions?, baseValence?, tags? }`) so e.g.
-  `attack` can gate on energy and carry a risk/threat prior.
+- **Per-effector metadata.** ✅ DONE (2026-07-05). `EffectorDeclaration` (types.ts)
+  = a bare name OR `{ name, description?, cost?, valence?, preconditions? }`.
+  `externalSchemas()` populates cost/baseValence/preconditions/description onto
+  the MotorSchema; they flow through the existing affordance build + selection
+  (an ability now gates on body state, carries a reward prior, competes on real
+  effort). `description` (the ability's meaning) rides schema → invocation →
+  host handler `ctx.description`, and travels in the PMA. Surfaced on the facade
+  as `create({ effectors: { name: { handler, description?, cost?, valence?,
+  preconditions? } } })`. Tests: agency.external-abilities + sdk.facade.
+  Still open here: `binds`/`tags` in the declaration (entity binding is its own
+  item below), and surfacing ability *meaning* into the deliberation context so
+  System 2 reads what each afforded ability is for.
 - **Field width.** N custom effectors all enter the floor uncapped. If hosts
   declare large catalogs, gate external affordances by attention/preconditions
   rather than emitting all of them every tick.

--- a/src/cognition/agency/engines/motor.schema.executor.ts
+++ b/src/cognition/agency/engines/motor.schema.executor.ts
@@ -464,6 +464,8 @@ export class MotorSchemaExecutor implements CognitiveEngine {
         payload: {
           schema: intent.schema, intentId: intent.id,
           targetEntityId: intent.targetEntityId, parameters: intent.parameters, tick,
+          // The ability's declared meaning, carried to the host handler.
+          description: this._resolve( intent.schema )?.description,
         },
       })
     }

--- a/src/cognition/agency/schemas/external.ts
+++ b/src/cognition/agency/schemas/external.ts
@@ -21,37 +21,50 @@
 // entity schema. See CUSTOM_EFFECTOR_WIRING_TODO.md.
 // ─────────────────────────────────────────────────────────────
 
-import type { MotorSchema } from '#agency/types'
+import type { MotorSchema, EffectorDeclaration } from '#agency/types'
 import { EXPLICIT_EFFECTORS } from '#agency/access.grants'
 import { INNATE_SCHEMA_BY_ID } from '#agency/schemas/innate'
 
 /** Default effort/energy demand for a host action when none is specified. */
 const DEFAULT_EXTERNAL_COST = 0.15
 
+const clamp = ( n: number, lo: number, hi: number ): number => n < lo ? lo : n > hi ? hi : n
+
 /**
  * Build enactable MotorSchemas for a host's declared domain effectors. Comms
  * names and innate-shadowing names are filtered out; the rest become objectless,
  * `external`-tagged primitives that route to the host on enaction.
+ *
+ * A declaration may be a bare name (uniform prior) or an object carrying the
+ * ability's meaning + intrinsic priors (`description`, `cost`, `valence`,
+ * `preconditions`) — these seed the affordance so the ability competes with a
+ * real effort/reward/gating profile instead of a flat default. Reafference
+ * refines them from there.
  */
-export function externalSchemas( effectors?: string[] | null ): MotorSchema[] {
+export function externalSchemas( effectors?: EffectorDeclaration[] | null ): MotorSchema[] {
   const seen = new Set<string>()
   const out:  MotorSchema[] = []
 
-  for( const name of effectors ?? [] ){
+  for( const decl of effectors ?? [] ){
+    const name = typeof decl === 'string' ? decl : decl?.name
     if( typeof name !== 'string' || name.length === 0 ) continue
     if( EXPLICIT_EFFECTORS.has( name ) )  continue   // communication — handled by AccessGrants
     if( INNATE_SCHEMA_BY_ID.has( name ) ) continue   // shadows an innate stance
     if( seen.has( name ) )                continue
     seen.add( name )
 
+    const meta = typeof decl === 'string' ? null : decl
+
     out.push({
-      id:          name,
-      kind:        'primitive',
-      source:      'external',
-      cost:        DEFAULT_EXTERNAL_COST,
-      binds:       'none',
-      baseValence: 0,
-      tags:        [ 'external', 'host' ],
+      id:            name,
+      kind:          'primitive',
+      source:        'external',
+      cost:          typeof meta?.cost === 'number' ? clamp( meta.cost, 0, 1 ) : DEFAULT_EXTERNAL_COST,
+      binds:         'none',
+      baseValence:   typeof meta?.valence === 'number' ? clamp( meta.valence, -1, 1 ) : 0,
+      ...( meta?.preconditions ? { preconditions: meta.preconditions } : {} ),
+      ...( meta?.description   ? { description:   meta.description   } : {} ),
+      tags:          [ 'external', 'host' ],
     })
   }
 

--- a/src/cognition/agency/schemas/repertoire.ts
+++ b/src/cognition/agency/schemas/repertoire.ts
@@ -221,6 +221,7 @@ function schemaEntity( s: MotorSchema ): EntityInput {
       preconditions: s.preconditions,
       composedOf:    s.composedOf,
       baseValence:   s.baseValence,
+      description:   s.description,
       tags:          s.tags,
     },
   }
@@ -241,6 +242,7 @@ function readSchema( m: Record<string, unknown> | undefined ): MotorSchema | und
     preconditions: meta['preconditions'] as MotorSchema['preconditions'],
     composedOf:    Array.isArray( meta['composedOf'] ) ? meta['composedOf'] as string[] : undefined,
     baseValence:   typeof meta['baseValence'] === 'number' ? meta['baseValence'] as number : undefined,
+    description:   typeof meta['description'] === 'string' ? meta['description'] as string : undefined,
     tags:          Array.isArray( meta['tags'] ) ? meta['tags'] as string[] : undefined,
   }
 }

--- a/src/cognition/agency/types.ts
+++ b/src/cognition/agency/types.ts
@@ -52,7 +52,36 @@ export interface MotorSchema {
   composedOf?:   string[]
   /** Intrinsic affective prior (−1..1) before any learning has occurred. */
   baseValence?:  number
+  /** What the schema is *for* — its meaning, carried to the host on enaction. */
+  description?:  string
   tags?:         string[]
+}
+
+/**
+ * How a host declares a domain effector to a Will. A bare string is the
+ * name-only form (`CUSTOM_ABILITY_WIRING.md` Phase 1). The object form seeds the
+ * ability as a *learnable affordance*: `description` is its meaning; `cost`,
+ * `valence`, and `preconditions` are the intrinsic priors the mind starts from
+ * before reafference refines them through use. Args still bind from the
+ * situation — this is not a tool-call parameter form.
+ */
+export type EffectorDeclaration =
+  | string
+  | {
+      name:           string
+      /** What the ability is for — its meaning, carried to perception + the host. */
+      description?:   string
+      /** Intrinsic effort/energy demand 0..1 (default 0.15). */
+      cost?:          number
+      /** Intrinsic affective prior −1..1 the mind expects before learning (default 0). */
+      valence?:       number
+      /** Body-state gates; the affordance is unavailable unless all pass. */
+      preconditions?: SchemaPrecondition[]
+    }
+
+/** The effector name of a declaration, whichever form it takes. */
+export function effectorName( d: EffectorDeclaration ): string {
+  return typeof d === 'string' ? d : d.name
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,4 +91,7 @@ export type {
   WillStateSummary,
   EffectorHandler,
   EffectorResult,
+  EffectorSpec,
+  EffectorEntry,
 } from '#sdk/will'
+export type { SchemaPrecondition, EffectorDeclaration } from '#agency/types'

--- a/src/sdk/will.ts
+++ b/src/sdk/will.ts
@@ -31,6 +31,7 @@ import { WillStem } from '#stem/index'
 import type { WillConfig, WillIdentity, EngineTier, ModelTier, InitialGoal } from '#stem/mind'
 import type { PMASnapshot } from '#pma/index'
 import type { effectorInvocation } from '#types'
+import type { EffectorDeclaration, SchemaPrecondition } from '#agency/types'
 
 // ── Public surface ────────────────────────────────────────────
 
@@ -97,8 +98,32 @@ export type EffectorResult = string | {
 /** Your implementation of an ability the Will can choose to use. */
 export type EffectorHandler = (
   args: Record<string, unknown>,
-  ctx: { reasoning: string; targetEntityId?: string },
+  ctx: { reasoning: string; targetEntityId?: string; description?: string },
 ) => EffectorResult | Promise<EffectorResult>
+
+/**
+ * A richer effector declaration — the ability seeded as a *learnable affordance*.
+ * `description` is its meaning (carried to perception + your handler); `cost`,
+ * `valence`, and `preconditions` are the intrinsic priors the mind starts from,
+ * refined by reafference through use. Args still bind from the situation — this
+ * is not a tool-call parameter form. Declare rich effectors in `create()`'s
+ * `effectors` map (that is where they enter the affordance repertoire).
+ */
+export interface EffectorSpec {
+  /** What the ability is for. */
+  description?: string
+  /** Intrinsic effort / energy demand 0..1 (default 0.15). */
+  cost?: number
+  /** Intrinsic reward prior −1..1 the mind expects before learning (default 0). */
+  valence?: number
+  /** Body-state gates; the ability is unavailable unless all pass. */
+  preconditions?: SchemaPrecondition[]
+  /** Your implementation. */
+  handler: EffectorHandler
+}
+
+/** An effectors-map value: a bare handler, or a spec carrying meaning + priors. */
+export type EffectorEntry = EffectorHandler | EffectorSpec
 
 /** A compact read of the mind's current inner state. */
 export interface WillStateSummary {
@@ -129,8 +154,13 @@ export interface CreateWillOptions {
    * (needs ANTHROPIC_API_KEY / WILL_LLM_* env). Omit to auto-detect.
    */
   llm?: 'mock' | 'anthropic'
-  /** Abilities the Will can choose to enact. name → your handler. */
-  effectors?: Record<string, EffectorHandler>
+  /**
+   * Abilities the Will can choose to enact. `name → handler`, or
+   * `name → { handler, description?, cost?, valence?, preconditions? }` to seed
+   * the ability with meaning + intrinsic priors (see EffectorSpec). Declared
+   * here (create time) so they enter the affordance repertoire.
+   */
+  effectors?: Record<string, EffectorEntry>
   /** Goals seeded before the first tick. Usually leave empty — the Will forms its own. */
   initialGoals?: InitialGoal[]
   /** Persist snapshots to disk across restarts (default false). */
@@ -166,6 +196,8 @@ export class Will {
   readonly name: string
 
   private readonly _effectors = new Map<string, EffectorHandler>()
+  /** Rich declarations for create-time effectors → seed the affordance repertoire. */
+  private readonly _effectorDecls = new Map<string, EffectorDeclaration>()
   private readonly _messageHandlers  = new Set<( m: WillMessage ) => void>()
   private readonly _stateHandlers    = new Set<( s: WillStateSummary ) => void>()
   private readonly _effectorHandlers = new Set<( a: WillEffectorAct ) => void>()
@@ -187,8 +219,8 @@ export class Will {
     const stem = new WillStem()
     const will = new Will( stem, id, opts.name )
 
-    for( const [ name, handler ] of Object.entries( opts.effectors ?? {} ) )
-      will._effectors.set( name, handler )
+    for( const [ name, entry ] of Object.entries( opts.effectors ?? {} ) )
+      will._register( name, entry )
 
     await stem.createWill( will._buildConfig( id, opts ) )
     will._attach()
@@ -208,8 +240,8 @@ export class Will {
     const stem = new WillStem()
     const will = new Will( stem, id, opts.name )
 
-    for( const [ name, handler ] of Object.entries( opts.effectors ?? {} ) )
-      will._effectors.set( name, handler )
+    for( const [ name, entry ] of Object.entries( opts.effectors ?? {} ) )
+      will._register( name, entry )
 
     await stem.createWill(
       will._buildConfig( id, { ...opts, identity: { prompt: '', ...opts.identity } } ),
@@ -283,16 +315,39 @@ export class Will {
    * is fed back as the outcome (closing the reafference loop that lets the Will
    * learn the ability). Registering makes the effector available immediately.
    *
-   * NOTE: this is the name-only form (`CUSTOM_ABILITY_WIRING.md` Phase 1) — the
-   * Will perceives the ability as an objectless affordance. Rich, schema'd
-   * effectors (`{ name, description, parameters, cost, … }` that feed affordance
-   * perception + deliberation) are a separate agency-layer increment (Phase 2).
+   * This post-create form registers the handler and grants the ability at
+   * runtime (name-only). To seed an ability with *meaning + intrinsic priors*
+   * (`description`, `cost`, `valence`, `preconditions`), declare it in
+   * `create()`'s `effectors` map — that is where it enters the affordance
+   * repertoire. (Rebuilding the repertoire for a runtime-added rich effector is
+   * a follow-up; see `CUSTOM_ABILITY_WIRING.md`.)
    */
   effector( name: string, handler: EffectorHandler ): this {
     this._effectors.set( name, handler )
     // Communication effectors + every registered custom name.
     this.stem.setAllowedEffectors( this.id, [ ...COMMUNICATION, ...this._effectors.keys() ] )
     return this
+  }
+
+  /** Split an effectors-map entry into a handler + an EffectorDeclaration. */
+  private _register( name: string, entry: EffectorEntry ): void {
+    if( typeof entry === 'function' ){
+      this._effectors.set( name, entry )
+      this._effectorDecls.set( name, name )          // bare name — uniform prior
+      return
+    }
+    this._effectors.set( name, entry.handler )
+    const hasMeta = entry.description !== undefined || entry.cost !== undefined
+      || entry.valence !== undefined || entry.preconditions !== undefined
+    this._effectorDecls.set( name, hasMeta
+      ? {
+          name,
+          ...( entry.description   !== undefined ? { description:   entry.description   } : {} ),
+          ...( entry.cost          !== undefined ? { cost:          entry.cost          } : {} ),
+          ...( entry.valence       !== undefined ? { valence:       entry.valence       } : {} ),
+          ...( entry.preconditions !== undefined ? { preconditions: entry.preconditions } : {} ),
+        }
+      : name )
   }
 
   // ── Introspection ──────────────────────────────────────────
@@ -387,7 +442,7 @@ export class Will {
       persistentMemory: opts.persist ?? false,
       snapshotInterval: 100,
       tickIntervalMs:   opts.tickMs ?? 1000,
-      allowedGenericEffectors: [ ...COMMUNICATION, ...this._effectors.keys() ],
+      allowedGenericEffectors: [ ...COMMUNICATION, ...this._effectorDecls.values() ],
       initialGoals: opts.initialGoals ?? [],
       ...( opts.seed !== undefined ? { randomSeed: opts.seed, clock: { fixedDeltaMs: 1000, startTime: 0 } } : {} ),
     }
@@ -433,7 +488,11 @@ export class Will {
     }
 
     try {
-      const raw = await handler( inv.parameters, { reasoning: inv.reasoning, targetEntityId: inv.targetEntityId } )
+      const raw = await handler( inv.parameters, {
+        reasoning: inv.reasoning,
+        targetEntityId: inv.targetEntityId,
+        ...( inv.description ? { description: inv.description } : {} ),
+      } )
       const result = typeof raw === 'string' ? { success: true, description: raw } : raw
       this.stem.confirmEffectorExecution( this.id, inv.decisionRecordId, result )
     }

--- a/src/stem/mind.ts
+++ b/src/stem/mind.ts
@@ -40,6 +40,7 @@ import { InstructionIntake }     from '#agency/engines/instruction.intake'
 import { SchemaRepertoire }      from '#agency/schemas/repertoire'
 import { INNATE_SCHEMAS }        from '#agency/schemas/innate'
 import { externalSchemas }       from '#agency/schemas/external'
+import { effectorName, type EffectorDeclaration } from '#agency/types'
 
 
 import {
@@ -260,8 +261,12 @@ export interface WillConfig {
    *
    * null or omitted = no communication effectors (minimal default).
    * Example: ['listen', 'talk', 'text'] enables inbound + text outbound.
+   *
+   * A domain effector may be a bare name or an object carrying its meaning +
+   * intrinsic priors: `{ name, description?, cost?, valence?, preconditions? }`
+   * (see EffectorDeclaration). Comms names are always bare.
    */
-  allowedGenericEffectors?: string[] | null
+  allowedGenericEffectors?: EffectorDeclaration[] | null
 
   /**
    * When true the executive engine uses a canned mock LLM response instead of
@@ -506,7 +511,7 @@ export function assembleMind( willId: string, config: WillConfig ): MindAssembly
   // creation; warnings surface; safe issues are sanitized in place.
   const idGuard = validateWillIdentity({
     identity:       config.identity,
-    effectors:      Array.isArray( config.allowedGenericEffectors ) ? config.allowedGenericEffectors : ( profile?.effectors ?? null ),
+    effectors:      ( Array.isArray( config.allowedGenericEffectors ) ? config.allowedGenericEffectors : ( profile?.effectors ?? null ) )?.map( effectorName ) ?? null,
     profileContext: profile?.context,
   })
   if( !idGuard.ok )
@@ -655,13 +660,15 @@ function _constructCognition(
   // This matters when a profile Will is created without specifying effectors:
   // the DB stores null, the service passes null, and profile effectors must win.
   // An empty array [] means "explicitly no effectors" (survives restart correctly).
-  const resolvedEffectors = Array.isArray( config.allowedGenericEffectors )
+  const resolvedEffectors: EffectorDeclaration[] | null = Array.isArray( config.allowedGenericEffectors )
     ? config.allowedGenericEffectors
     : ( profile?.effectors ?? null )
+  // Name-only view for the grant / permission surfaces (comms gating is by name).
+  const resolvedEffectorNames = resolvedEffectors?.map( effectorName ) ?? null
 
   // Agency-native permission / sense-gate authority, seeded from the resolved
   // grant list. The senses + reply path read this. (Replaced effectorRegistry.)
-  const accessGrants = new AccessGrants( resolvedEffectors )
+  const accessGrants = new AccessGrants( resolvedEffectorNames )
 
   // ── Executive Engine ────────────────────────────────────────
   // Created for all tiers so the Cognition type is always satisfied.

--- a/src/stem/tracts/effector.controller.ts
+++ b/src/stem/tracts/effector.controller.ts
@@ -51,6 +51,7 @@ export class effectorController {
       parameters:       ( payload.parameters as Record<string, unknown> ) ?? {},
       targetEntityId:   payload.targetEntityId as string | undefined,
       reasoning:        ( payload.reasoning as string ) ?? '',
+      ...( typeof payload.description === 'string' ? { description: payload.description } : {} ),
       tick:             ( payload.tick as number ) ?? 0,
       timestamp:        Date.now()
     })

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,8 @@ export interface effectorInvocation {
   parameters:       Record<string, unknown>
   targetEntityId:   string | undefined
   reasoning:        string
+  /** The ability's declared meaning (from its EffectorDeclaration), when present. */
+  description?:     string
   tick:             number
   timestamp:        number
 }

--- a/tests/unit/agency.external-abilities.test.ts
+++ b/tests/unit/agency.external-abilities.test.ts
@@ -43,3 +43,46 @@ describe( 'agency — host-owned custom effectors reach the field', () => {
     expect( bySchema.has( 'talk' ) ).toBe( false )             // comms are not external floor affordances
   } )
 } )
+
+describe( 'agency — rich effector declarations (Phase 2)', () => {
+  it( 'seeds cost / valence / preconditions / description onto the schema', () => {
+    const [ give ] = externalSchemas( [ {
+      name: 'give', description: 'Offer an item to someone present',
+      cost: 0.4, valence: 0.3,
+      preconditions: [ { metric: 'energy.level', op: 'gte', value: 20 } ],
+    } ] )
+    expect( give ).toMatchObject( {
+      id: 'give', source: 'external', binds: 'none',
+      cost: 0.4, baseValence: 0.3,
+      description: 'Offer an item to someone present',
+      preconditions: [ { metric: 'energy.level', op: 'gte', value: 20 } ],
+    } )
+  } )
+
+  it( 'a bare name keeps the flat defaults (back-compat)', () => {
+    const [ move ] = externalSchemas( [ 'move' ] )
+    expect( move ).toMatchObject( { id: 'move', cost: 0.15, baseValence: 0 } )
+    expect( move!.description ).toBeUndefined()
+    expect( move!.preconditions ).toBeUndefined()
+  } )
+
+  it( 'mixes bare names and rich objects, and clamps out-of-range cost/valence', () => {
+    const schemas = externalSchemas( [ 'move', { name: 'lunge', cost: 5, valence: -9 } ] )
+    expect( schemas.map( s => s.id ) ).toEqual( [ 'move', 'lunge' ] )
+    expect( schemas[1] ).toMatchObject( { cost: 1, baseValence: -1 } )   // clamped
+  } )
+
+  it( 'a failing precondition makes the affordance unavailable; a passing one keeps it available', async () => {
+    const repertoire = new SchemaRepertoire( [ ...INNATE_SCHEMAS, ...externalSchemas( [
+      { name: 'sprint', preconditions: [ { metric: 'energy.level', op: 'gte', value: 50 } ] },
+    ] ) ] )
+    const synth = new AffordanceSynthesizer(); synth.attachRepertoire( repertoire )
+    const avail = async ( energy: number ): Promise<boolean> => {
+      const state = { tick: 1, time: 0, entities: new Map(), metrics: new Map( [ [ 'energy.level', energy ] ] ) } as any
+      const field = ( ( await synth.react( 0, 1, state, CTX ) ).commands?.set ?? [] ).filter( ( e: any ) => e.type === 'affordance' )
+      return ( new Map( field.map( ( e: any ) => [ e.metadata?.schema, e.metadata ] ) ).get( 'sprint' ) as any )?.available
+    }
+    expect( await avail( 10 ) ).toBe( false )   // below the gate
+    expect( await avail( 80 ) ).toBe( true )    // above the gate
+  } )
+} )

--- a/tests/unit/sdk.facade.test.ts
+++ b/tests/unit/sdk.facade.test.ts
@@ -126,6 +126,32 @@ describe( 'Will facade — subject surface', () => {
     finally { await will.stop() }
   }, 30_000 )
 
+  it( 'a rich effector declaration seeds the affordance repertoire with meaning + priors', async () => {
+    const will = await Will.create( { ...base, name: 'Rich', identity: { prompt: 'I act.' },
+      effectors: {
+        forage: {
+          handler:       async () => 'ok',
+          description:   'Search the area for food',
+          cost:          0.35,
+          valence:       0.4,
+          preconditions: [ { metric: 'energy.level', op: 'gte', value: 15 } ],
+        },
+        wave: async () => 'ok',   // bare handler — back-compat, flat defaults
+      },
+    } )
+    try {
+      const repertoire = ( will.stem.getWillCognition( will.id ) as unknown as { schemaRepertoire: { getSchema( id: string ): any } } ).schemaRepertoire
+      const forage = repertoire.getSchema( 'forage' )
+      expect( forage ).toMatchObject( { cost: 0.35, baseValence: 0.4, description: 'Search the area for food' } )
+      expect( forage.preconditions?.[0] ).toMatchObject( { metric: 'energy.level', op: 'gte', value: 15 } )
+
+      const wave = repertoire.getSchema( 'wave' )
+      expect( wave ).toMatchObject( { cost: 0.15, baseValence: 0 } )   // flat defaults
+      expect( wave.description ).toBeUndefined()
+    }
+    finally { await will.stop() }
+  }, 30_000 )
+
   it( 'perceive() is the intake say/tell route through, and does not stall ticking', async () => {
     const will = await Will.create( { ...base, name: 'Ears', identity: { prompt: 'I listen.' } } )
     try {


### PR DESCRIPTION
Phase 2 of `CUSTOM_ABILITY_WIRING.md`, done in **Will's idiom** — a host declares an ability the way a mind comes to know one: not a tool-call signature, but a **learnable affordance seeded with meaning + intrinsic priors**. (Follows the design discussion: a subject that *finds* its actions in the situation, never a form-filling agent.)

## What changes
An effector may now be declared as `{ name, description?, cost?, valence?, preconditions? }` (the bare-string form still works). These flow through the **existing** afford → select → enact → reafference loop — no new deliberation path:

- **`cost` / `valence` / `preconditions`** populate the `MotorSchema`, so the ability **gates on body state**, carries a **reward prior**, and competes on **real effort** — before, every custom effector was a flat `cost 0.15`, `valence 0`, no gates.
- **`description`** (the ability's *meaning*) rides `schema → invocation → ctx.description` to the host handler, and travels in the PMA schema mirror.
- **Args still bind from the situation** — this is *not* an LLM-filled parameter form.

## Surface
```ts
await Will.create({
  effectors: {
    give: { handler, description: 'Offer an item to someone present',
            cost: 0.2, valence: 0.3,
            preconditions: [{ metric: 'energy.level', op: 'gte', value: 10 }] },
    wave: async () => 'ok',            // bare handler — flat defaults, back-compat
  },
})
```
`allowedGenericEffectors` accepts `EffectorDeclaration[]`; names are normalized for the grant/identity surfaces (comms gating stays by name).

## Deliberately out of scope (their own increments)
- **Entity-binding** (an ability targeting a specific perceived entity — `binds`).
- **Deliberation-surfacing** (System 2 reading each afforded ability's meaning).
- Post-create `.effector()` stays name-only — runtime repertoire rebuild is a follow-up.

## Tests
`agency.external-abilities` (rich schema fields, clamping, precondition gates the affordance available/unavailable) + `sdk.facade` (rich declaration reaches the repertoire through `create()`). Full suite **918 pass / 2 skip / 0 fail**, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)