### PR TITLE
feat(agency): entity-binding for effectors (direct an ability at a person)

### DIFF
--- a/.TODO/CUSTOM_ABILITY_WIRING.md
+++ b/.TODO/CUSTOM_ABILITY_WIRING.md
@@ -43,11 +43,16 @@ feeds the agency learning loop like any other action.
 
 ## Phase 2+ — follow-ups
 
-- **Entity binding.** External effectors are objectless today (the host resolves
-  the target). The synthesizer binds a *single* entity schema (`reach-out`); to
-  let `attack`/`give`/`trade` target a *specific* perceived entity, generalise
-  the entity-binding pass to bind N entity-binding schemas, and let an effector
-  declare `binds: 'entity'`.
+- **Entity binding.** ✅ DONE (2026-07-05). An effector may declare `binds: 'entity'`
+  (EffectorDeclaration / facade EffectorSpec); `externalSchemas()` sets it, and the
+  AffordanceSynthesizer's entity pass was generalised from a single `find` to
+  `filter( s => s.binds === 'entity' )` — every entity-bound schema (innate
+  `reach-out` PLUS host effectors) is now bound against each perceived *sentient*
+  known-entity, so the Will can `give`/`greet`/… someone in particular. The bound
+  target reaches the host as `ctx.targetEntityId`; ids stay unique per
+  (schema × entity). Tests: agency.external-abilities + sdk.facade.
+  Still open: binding to non-sentient `'thing'` entities (objects/tools) — needs
+  object perception in the entity pass.
 - **Per-effector metadata.** ✅ DONE (2026-07-05). `EffectorDeclaration` (types.ts)
   = a bare name OR `{ name, description?, cost?, valence?, preconditions? }`.
   `externalSchemas()` populates cost/baseValence/preconditions/description onto

--- a/src/cognition/agency/engines/affordance.synthesizer.ts
+++ b/src/cognition/agency/engines/affordance.synthesizer.ts
@@ -149,8 +149,13 @@ export class AffordanceSynthesizer implements CognitiveEngine {
         })
       }
 
-    const entitySchema = schemas.find( s => s.binds === 'entity' )
-    if( entitySchema )
+    // Every `binds: 'entity'` schema — the innate `reach-out` PLUS any host
+    // effector declared entity-bound — is bound against each perceived sentient
+    // entity, so the Will can direct e.g. `give`/`greet` at someone in particular.
+    // Each (schema × entity) enters as a candidate at the entity's salience and
+    // competes through the attention cap like anything else.
+    const entitySchemas = schemas.filter( s => s.binds === 'entity' )
+    if( entitySchemas.length > 0 )
       for( const [ id, e ] of state.entities ){
         if( e.type !== 'known-entity' ) continue
         const m = e.metadata
@@ -159,14 +164,17 @@ export class AffordanceSynthesizer implements CognitiveEngine {
         const fam  = num( m?.['familiarity'], 0 )
         const val  = num( m?.['valence'], 0 )
         const res  = num( m?.['resolutionConfidence'], 0 )
-        candidates.push({
-          salience: fam * 0.6 + Math.max( 0, val ) * 0.3 + res * 0.1 + ( goalTargets.get( keid ) ?? 0 ),
-          affordance: this._build( entitySchema, tick, state, valence, energyLow, skills, {
-            evokedBy:       id,
-            targetEntityId: keid,
-            parameters:     { targetEntityName: str( m?.['name'] ) ?? keid },
-          } ),
-        })
+        const salience = fam * 0.6 + Math.max( 0, val ) * 0.3 + res * 0.1 + ( goalTargets.get( keid ) ?? 0 )
+        const name     = str( m?.['name'] ) ?? keid
+        for( const entitySchema of entitySchemas )
+          candidates.push({
+            salience,
+            affordance: this._build( entitySchema, tick, state, valence, energyLow, skills, {
+              evokedBy:       id,
+              targetEntityId: keid,
+              parameters:     { targetEntityName: name },
+            } ),
+          })
       }
 
     // ── ideomotor candidates: the executive's imagined actions, pre-activated ──

--- a/src/cognition/agency/schemas/external.ts
+++ b/src/cognition/agency/schemas/external.ts
@@ -60,7 +60,7 @@ export function externalSchemas( effectors?: EffectorDeclaration[] | null ): Mot
       kind:          'primitive',
       source:        'external',
       cost:          typeof meta?.cost === 'number' ? clamp( meta.cost, 0, 1 ) : DEFAULT_EXTERNAL_COST,
-      binds:         'none',
+      binds:         meta?.binds === 'entity' ? 'entity' : 'none',
       baseValence:   typeof meta?.valence === 'number' ? clamp( meta.valence, -1, 1 ) : 0,
       ...( meta?.preconditions ? { preconditions: meta.preconditions } : {} ),
       ...( meta?.description   ? { description:   meta.description   } : {} ),

--- a/src/cognition/agency/types.ts
+++ b/src/cognition/agency/types.ts
@@ -77,6 +77,13 @@ export type EffectorDeclaration =
       valence?:       number
       /** Body-state gates; the affordance is unavailable unless all pass. */
       preconditions?: SchemaPrecondition[]
+      /**
+       * Whether the ability targets a specific *perceived* entity (default
+       * 'none'). 'entity' binds it to each sentient known-entity in the field,
+       * so the Will can `give`/`greet`/… someone in particular; the bound target
+       * reaches the host as `ctx.targetEntityId`.
+       */
+      binds?:         'none' | 'entity'
     }
 
 /** The effector name of a declaration, whichever form it takes. */

--- a/src/sdk/will.ts
+++ b/src/sdk/will.ts
@@ -118,6 +118,12 @@ export interface EffectorSpec {
   valence?: number
   /** Body-state gates; the ability is unavailable unless all pass. */
   preconditions?: SchemaPrecondition[]
+  /**
+   * Whether the ability targets a specific perceived entity (default 'none').
+   * 'entity' lets the Will direct it at a particular known person in the field;
+   * the bound target arrives as `ctx.targetEntityId`.
+   */
+  binds?: 'none' | 'entity'
   /** Your implementation. */
   handler: EffectorHandler
 }
@@ -338,7 +344,7 @@ export class Will {
     }
     this._effectors.set( name, entry.handler )
     const hasMeta = entry.description !== undefined || entry.cost !== undefined
-      || entry.valence !== undefined || entry.preconditions !== undefined
+      || entry.valence !== undefined || entry.preconditions !== undefined || entry.binds !== undefined
     this._effectorDecls.set( name, hasMeta
       ? {
           name,
@@ -346,6 +352,7 @@ export class Will {
           ...( entry.cost          !== undefined ? { cost:          entry.cost          } : {} ),
           ...( entry.valence       !== undefined ? { valence:       entry.valence       } : {} ),
           ...( entry.preconditions !== undefined ? { preconditions: entry.preconditions } : {} ),
+          ...( entry.binds         !== undefined ? { binds:         entry.binds         } : {} ),
         }
       : name )
   }

--- a/tests/unit/agency.external-abilities.test.ts
+++ b/tests/unit/agency.external-abilities.test.ts
@@ -86,3 +86,41 @@ describe( 'agency — rich effector declarations (Phase 2)', () => {
     expect( await avail( 80 ) ).toBe( true )    // above the gate
   } )
 } )
+
+describe( 'agency — entity-bound effectors', () => {
+  const personState = () => ( {
+    tick: 1, time: 0,
+    entities: new Map( [ [ 'ke-ada', { type: 'known-entity', metadata: {
+      keid: 'ada', kind: 'sentient', name: 'Ada',
+      familiarity: 0.8, valence: 0.5, resolutionConfidence: 0.9,
+    } } ] ] ),
+    metrics: new Map(),
+  } as any )
+
+  it( 'declares binds:entity on the schema (default stays none)', () => {
+    expect( externalSchemas( [ { name: 'give', binds: 'entity' } ] )[0]!.binds ).toBe( 'entity' )
+    expect( externalSchemas( [ { name: 'ponder' } ] )[0]!.binds ).toBe( 'none' )
+    expect( externalSchemas( [ 'move' ] )[0]!.binds ).toBe( 'none' )
+  } )
+
+  it( 'binds an entity-effector to each perceived sentient entity, alongside innate reach-out', async () => {
+    const repertoire = new SchemaRepertoire( [ ...INNATE_SCHEMAS, ...externalSchemas( [ { name: 'give', binds: 'entity' } ] ) ] )
+    const synth = new AffordanceSynthesizer(); synth.attachRepertoire( repertoire )
+    const field = ( ( await synth.react( 0, 1, personState(), CTX ) ).commands?.set ?? [] ).filter( ( e: any ) => e.type === 'affordance' )
+
+    const give = field.find( ( e: any ) => e.metadata?.schema === 'give' )
+    expect( give?.metadata?.targetEntityId ).toBe( 'ada' )                    // bound to the person
+    expect( ( give?.metadata?.parameters as any )?.targetEntityName ).toBe( 'Ada' )
+    // additive, not a replacement: the innate entity schema still binds too
+    expect( field.some( ( e: any ) => e.metadata?.schema === 'reach-out' && e.metadata?.targetEntityId === 'ada' ) ).toBe( true )
+  } )
+
+  it( 'leaves an objectless (binds:none) effector unbound — floor affordance, no target', async () => {
+    const repertoire = new SchemaRepertoire( [ ...INNATE_SCHEMAS, ...externalSchemas( [ { name: 'wander' } ] ) ] )
+    const synth = new AffordanceSynthesizer(); synth.attachRepertoire( repertoire )
+    const field = ( ( await synth.react( 0, 1, personState(), CTX ) ).commands?.set ?? [] ).filter( ( e: any ) => e.type === 'affordance' )
+    const wander = field.filter( ( e: any ) => e.metadata?.schema === 'wander' )
+    expect( wander.length ).toBe( 1 )                          // one floor affordance
+    expect( wander[0]?.metadata?.targetEntityId ).toBeUndefined()   // never targeted at the person
+  } )
+} )

--- a/tests/unit/sdk.facade.test.ts
+++ b/tests/unit/sdk.facade.test.ts
@@ -152,6 +152,17 @@ describe( 'Will facade — subject surface', () => {
     finally { await will.stop() }
   }, 30_000 )
 
+  it( 'a binds:entity effector reaches the repertoire as an entity-bound schema', async () => {
+    const will = await Will.create( { ...base, name: 'Greeter', identity: { prompt: 'I greet.' },
+      effectors: { greet: { handler: async () => 'ok', binds: 'entity', description: 'Greet someone by name' } },
+    } )
+    try {
+      const repertoire = ( will.stem.getWillCognition( will.id ) as unknown as { schemaRepertoire: { getSchema( id: string ): any } } ).schemaRepertoire
+      expect( repertoire.getSchema( 'greet' ) ).toMatchObject( { binds: 'entity', description: 'Greet someone by name' } )
+    }
+    finally { await will.stop() }
+  }, 30_000 )
+
   it( 'perceive() is the intake say/tell route through, and does not stall ticking', async () => {
     const will = await Will.create( { ...base, name: 'Ears', identity: { prompt: 'I listen.' } } )
     try {


### PR DESCRIPTION
Phase 2 follow-up (`CUSTOM_ABILITY_WIRING.md`). Lets a host effector target a **specific perceived person** instead of acting objectlessly — the structural-relevance path (`give`/`greet`/`thank` *someone*).

## What changes
- **`binds: 'none' | 'entity'`** on `EffectorDeclaration` + facade `EffectorSpec` (default `'none'`); `externalSchemas()` sets it on the `MotorSchema`.
- **Generalised the synthesizer's entity pass** from `find(s => s.binds === 'entity')` (only the innate `reach-out`) to `filter(...)` over *all* entity-bound schemas. Each entity-bound ability (innate + host) is bound against every perceived **sentient** known-entity as a capped candidate. Additive — `reach-out` still binds; affordance ids stay unique per `(schema × entity)`.
- The bound target flows to the host as **`ctx.targetEntityId`**.

```ts
await Will.create({
  effectors: {
    give: { handler, binds: 'entity', description: 'Offer an item to someone present' },
  },
})
// when the Will chooses `give` against Ada, the handler gets ctx.targetEntityId === 'ada'
```

## Still out of scope
Binding to non-sentient `'thing'` entities (objects/tools) — needs object perception in the entity pass. Noted in the TODO.

## Tests
`agency.external-abilities` (binds:entity on the schema; the effector bound to a sentient entity with the target + name; objectless effector stays unbound) + `sdk.facade` (binds:entity reaches the repertoire). Full suite **922 pass / 2 skip / 0 fail**, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)