### PR TITLE
feat(agency): deliberation candidates carry their meaning (not bare labels)

### DIFF
--- a/.TODO/CUSTOM_ABILITY_WIRING.md
+++ b/.TODO/CUSTOM_ABILITY_WIRING.md
@@ -67,8 +67,12 @@ feeds the agency learning loop like any other action.
   `ExecutiveContext.abilities` (context.ts `extractAbilities`) and rendered as
   "## Abilities Available Now" in the executive prompt — framed as self-knowledge
   (what you can do), NOT a tool-call menu. `description` now also rides onto the
-  affordance entity. Tests: executive.abilities-awareness. Still open: `tags` in
-  the declaration.
+  affordance entity. AND the DeliberationEngine's candidate list (the specific
+  options System 2 chooses between when a competition is contested) now renders
+  each candidate's meaning too — `ActionSelector` carries `description` onto the
+  deliberating candidates and `_buildFocusContent` shows `give toward ada —
+  <meaning>` instead of a bare label. Tests: executive.abilities-awareness,
+  agency.deliberation. Still open: `tags` in the declaration.
 - **Field width.** N custom effectors all enter the floor uncapped. If hosts
   declare large catalogs, gate external affordances by attention/preconditions
   rather than emitting all of them every tick.

--- a/src/cognition/agency/engines/action.selector.ts
+++ b/src/cognition/agency/engines/action.selector.ts
@@ -293,6 +293,9 @@ export class ActionSelector implements CognitiveEngine {
               targetEntityId: s.affordance.targetEntityId,
               parameters:     s.affordance.parameters,
               activation:     s.activation,
+              // Carry the ability's meaning so the Deliberator weighs what each
+              // option is FOR, not bare labels.
+              ...( s.affordance.description ? { description: s.affordance.description } : {} ),
               // Channel B: flag a candidate that is an active plan's frontier step, so
               // the deliberation facet can own "this is my plan's next step" in-character.
               ...( s.affordance.source === 'plan' ? { fromPlan: true } : {} ),

--- a/src/cognition/agency/engines/deliberation.engine.ts
+++ b/src/cognition/agency/engines/deliberation.engine.ts
@@ -50,6 +50,8 @@ interface Candidate {
   targetEntityId?: string
   parameters?:     Record<string, unknown>
   activation?:     number
+  /** The ability's declared meaning (external effectors) — what it is for. */
+  description?:    string
   /** Channel B: this candidate is an active plan's current frontier step. */
   fromPlan?:       boolean
 }
@@ -212,10 +214,13 @@ export class DeliberationEngine implements CognitiveEngine {
       lines.push( 'Your automatic action-selection was uncertain. Candidate actions:' )
     candidates.forEach( ( c, i ) => {
       const to   = c.targetEntityId ? ` toward ${ c.targetEntityId }` : ''
+      // The ability's meaning, so the facet weighs what each option IS FOR rather
+      // than choosing among bare labels ("give" vs "attack" is a real difference).
+      const what = c.description ? ` — ${ c.description }` : ''
       // Channel B: name the plan link so the facet chooses as the self pursuing it,
       // not blindly among labels ("this one is the next step of the plan I'm on").
-      const plan = c.fromPlan ? " — your current plan's next step" : ''
-      lines.push( `${ i + 1 }. ${ c.schema }${ to }${ plan }` )
+      const plan = c.fromPlan ? " (your current plan's next step)" : ''
+      lines.push( `${ i + 1 }. ${ c.schema }${ to }${ what }${ plan }` )
     })
     return lines.join( '\n' )
   }

--- a/tests/unit/agency.deliberation.test.ts
+++ b/tests/unit/agency.deliberation.test.ts
@@ -120,6 +120,20 @@ describe( 'DeliberationEngine — Channel B: owns a preemption in-character', ()
     }), CTX )
     expect( cap.focus().toLowerCase() ).toContain( "plan's next step" )
   })
+
+  it( "surfaces each candidate's MEANING so the facet weighs what it's for, not bare labels", async () => {
+    const eng = new DeliberationEngine()
+    const cap = capturingProvider( 'give' )
+    eng.attachExecutive( cap.provider )
+    await eng.react( 0, 1, deliberating({
+      candidates: [
+        { schema: 'give',  targetEntityId: 'ada', description: 'Offer an item to someone present' },
+        { schema: 'shove', targetEntityId: 'ada', description: 'Push someone away from you' },
+      ],
+    }), CTX )
+    expect( cap.focus() ).toContain( 'give toward ada — Offer an item to someone present' )
+    expect( cap.focus() ).toContain( 'shove toward ada — Push someone away from you' )
+  })
 })
 
 describe( 'DeliberationEngine — graceful System-1 degradation', () => {


### PR DESCRIPTION
Follow-up to #23 — closes a gap it missed (thanks @fabrice8 for catching it).

#23 surfaced afforded abilities into the **general** executive context, which the deliberation facet inherits via the unified `PromptFactory`. But the **DeliberationEngine's own candidate list** — the specific options System 2 is choosing between when a competition is contested (`_buildFocusContent`) — still rendered each candidate as a **bare `schema` name + target**:

```
1. give toward ada
2. shove toward ada
```

So at the exact moment the mind weighs `give` vs `shove`, it saw labels, not what each *means*.

## Fix
- `ActionSelector` carries `description` onto each deliberating candidate (the affordance already has it since #23).
- `DeliberationEngine.Candidate` gains `description`; `_buildFocusContent` now renders:
  ```
  1. give toward ada — Offer an item to someone present
  2. shove toward ada — Push someone away from you
  ```
- The plan-step framing moved to parentheses so it composes with the new meaning clause (existing test intact).

## Tests
`agency.deliberation` — a new case asserting each candidate's meaning appears in the facet focus. Full suite **927 pass / 2 skip / 0 fail**, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)