### PR TITLE
feat(agency): object-binding + routing tags for effectors

### DIFF
--- a/src/cognition/agency/engines/affordance.synthesizer.ts
+++ b/src/cognition/agency/engines/affordance.synthesizer.ts
@@ -149,27 +149,31 @@ export class AffordanceSynthesizer implements CognitiveEngine {
         })
       }
 
-    // Every `binds: 'entity'` schema — the innate `reach-out` PLUS any host
-    // effector declared entity-bound — is bound against each perceived sentient
-    // entity, so the Will can direct e.g. `give`/`greet` at someone in particular.
-    // Each (schema × entity) enters as a candidate at the entity's salience and
-    // competes through the attention cap like anything else.
-    const entitySchemas = schemas.filter( s => s.binds === 'entity' )
-    if( entitySchemas.length > 0 )
+    // Target-bound schemas are bound against each perceived known-entity of the
+    // matching kind: `binds: 'entity'` schemas (innate `reach-out` + host
+    // person-effectors) to sentient entities, `binds: 'object'` schemas to
+    // things — so the Will can direct `give`/`greet` at someone or `use`/`pick-up`
+    // at something in particular. Each (schema × target) enters as a candidate at
+    // the target's salience and competes through the attention cap.
+    const personSchemas = schemas.filter( s => s.binds === 'entity' )
+    const objectSchemas = schemas.filter( s => s.binds === 'object' )
+    if( personSchemas.length > 0 || objectSchemas.length > 0 )
       for( const [ id, e ] of state.entities ){
         if( e.type !== 'known-entity' ) continue
-        const m = e.metadata
-        if( str( m?.['kind'] ) !== 'sentient' ) continue
+        const m    = e.metadata
+        const kind = str( m?.['kind'] )
+        const applicable = kind === 'sentient' ? personSchemas : kind === 'thing' ? objectSchemas : null
+        if( !applicable || applicable.length === 0 ) continue
         const keid = str( m?.['keid'] ) ?? id
         const fam  = num( m?.['familiarity'], 0 )
         const val  = num( m?.['valence'], 0 )
         const res  = num( m?.['resolutionConfidence'], 0 )
         const salience = fam * 0.6 + Math.max( 0, val ) * 0.3 + res * 0.1 + ( goalTargets.get( keid ) ?? 0 )
         const name     = str( m?.['name'] ) ?? keid
-        for( const entitySchema of entitySchemas )
+        for( const schema of applicable )
           candidates.push({
             salience,
-            affordance: this._build( entitySchema, tick, state, valence, energyLow, skills, {
+            affordance: this._build( schema, tick, state, valence, energyLow, skills, {
               evokedBy:       id,
               targetEntityId: keid,
               parameters:     { targetEntityName: name },

--- a/src/cognition/agency/schemas/external.ts
+++ b/src/cognition/agency/schemas/external.ts
@@ -54,17 +54,21 @@ export function externalSchemas( effectors?: EffectorDeclaration[] | null ): Mot
     seen.add( name )
 
     const meta = typeof decl === 'string' ? null : decl
+    const binds = meta?.binds === 'entity' ? 'entity' : meta?.binds === 'object' ? 'object' : 'none'
+    // Declared routing tags merged with the mandatory 'external'/'host' markers
+    // (the executor routes on 'external'; dedup keeps the set clean).
+    const tags = [ ...new Set( [ ...( meta?.tags ?? [] ), 'external', 'host' ] ) ]
 
     out.push({
       id:            name,
       kind:          'primitive',
       source:        'external',
       cost:          typeof meta?.cost === 'number' ? clamp( meta.cost, 0, 1 ) : DEFAULT_EXTERNAL_COST,
-      binds:         meta?.binds === 'entity' ? 'entity' : 'none',
+      binds,
       baseValence:   typeof meta?.valence === 'number' ? clamp( meta.valence, -1, 1 ) : 0,
       ...( meta?.preconditions ? { preconditions: meta.preconditions } : {} ),
       ...( meta?.description   ? { description:   meta.description   } : {} ),
-      tags:          [ 'external', 'host' ],
+      tags,
     })
   }
 

--- a/src/cognition/agency/types.ts
+++ b/src/cognition/agency/types.ts
@@ -29,8 +29,12 @@ export interface SchemaPrecondition {
   value:  number
 }
 
-/** What kind of target a schema binds when it becomes an affordance. */
-export type SchemaBinding = 'none' | 'entity' | 'percept'
+/**
+ * What kind of target a schema binds when it becomes an affordance.
+ * 'entity' = a sentient known-entity (a person); 'object' = a non-sentient
+ * known-entity (a thing); 'percept' = a salient percept; 'none' = objectless.
+ */
+export type SchemaBinding = 'none' | 'entity' | 'object' | 'percept'
 
 /**
  * A MotorSchema — a parameterized control program, not a flat effector row.
@@ -78,12 +82,19 @@ export type EffectorDeclaration =
       /** Body-state gates; the affordance is unavailable unless all pass. */
       preconditions?: SchemaPrecondition[]
       /**
-       * Whether the ability targets a specific *perceived* entity (default
-       * 'none'). 'entity' binds it to each sentient known-entity in the field,
-       * so the Will can `give`/`greet`/… someone in particular; the bound target
-       * reaches the host as `ctx.targetEntityId`.
+       * Whether the ability targets a specific *perceived* target (default
+       * 'none'). 'entity' binds it to each sentient known-entity (a person),
+       * 'object' to each non-sentient one (a thing) — so the Will can
+       * `give`/`greet` someone or `use`/`pick-up` something in particular; the
+       * bound target reaches the host as `ctx.targetEntityId`.
        */
-      binds?:         'none' | 'entity'
+      binds?:         'none' | 'entity' | 'object'
+      /**
+       * Routing tags folded into the schema (merged with 'external'/'host').
+       * A tag the drive system recognises (e.g. 'social', 'nourishment') lets a
+       * homeostatic drive lift this ability in the competition when pressing.
+       */
+      tags?:          string[]
     }
 
 /** The effector name of a declaration, whichever form it takes. */

--- a/src/sdk/will.ts
+++ b/src/sdk/will.ts
@@ -119,11 +119,17 @@ export interface EffectorSpec {
   /** Body-state gates; the ability is unavailable unless all pass. */
   preconditions?: SchemaPrecondition[]
   /**
-   * Whether the ability targets a specific perceived entity (default 'none').
-   * 'entity' lets the Will direct it at a particular known person in the field;
-   * the bound target arrives as `ctx.targetEntityId`.
+   * Whether the ability targets a specific perceived target (default 'none').
+   * 'entity' directs it at a known person, 'object' at a known thing; the bound
+   * target arrives as `ctx.targetEntityId`.
    */
-  binds?: 'none' | 'entity'
+  binds?: 'none' | 'entity' | 'object'
+  /**
+   * Routing tags (merged with 'external'/'host'). A drive-recognised tag (e.g.
+   * 'social', 'nourishment') lets a homeostatic drive lift this ability when it
+   * presses.
+   */
+  tags?: string[]
   /** Your implementation. */
   handler: EffectorHandler
 }
@@ -344,7 +350,8 @@ export class Will {
     }
     this._effectors.set( name, entry.handler )
     const hasMeta = entry.description !== undefined || entry.cost !== undefined
-      || entry.valence !== undefined || entry.preconditions !== undefined || entry.binds !== undefined
+      || entry.valence !== undefined || entry.preconditions !== undefined
+      || entry.binds !== undefined || entry.tags !== undefined
     this._effectorDecls.set( name, hasMeta
       ? {
           name,
@@ -353,6 +360,7 @@ export class Will {
           ...( entry.valence       !== undefined ? { valence:       entry.valence       } : {} ),
           ...( entry.preconditions !== undefined ? { preconditions: entry.preconditions } : {} ),
           ...( entry.binds         !== undefined ? { binds:         entry.binds         } : {} ),
+          ...( entry.tags          !== undefined ? { tags:          entry.tags          } : {} ),
         }
       : name )
   }

--- a/tests/unit/agency.external-abilities.test.ts
+++ b/tests/unit/agency.external-abilities.test.ts
@@ -124,3 +124,37 @@ describe( 'agency — entity-bound effectors', () => {
     expect( wander[0]?.metadata?.targetEntityId ).toBeUndefined()   // never targeted at the person
   } )
 } )
+
+describe( 'agency — object-binding + routing tags', () => {
+  const mixedState = () => ( {
+    tick: 1, time: 0,
+    entities: new Map( [
+      [ 'ke-ada', { type: 'known-entity', metadata: { keid: 'ada', kind: 'sentient', name: 'Ada', familiarity: 0.8 } } ],
+      [ 'ke-axe', { type: 'known-entity', metadata: { keid: 'axe', kind: 'thing',    name: 'Axe', familiarity: 0.5 } } ],
+    ] ),
+    metrics: new Map(),
+  } as any )
+
+  it( 'merges declared tags with external/host (deduped)', () => {
+    const [ s ] = externalSchemas( [ { name: 'forage', tags: [ 'nourishment', 'external' ] } ] )
+    expect( s!.tags ).toEqual( expect.arrayContaining( [ 'nourishment', 'external', 'host' ] ) )
+    expect( s!.tags!.filter( t => t === 'external' ).length ).toBe( 1 )   // deduped
+  } )
+
+  it( 'declares binds:object on the schema', () => {
+    expect( externalSchemas( [ { name: 'use', binds: 'object' } ] )[0]!.binds ).toBe( 'object' )
+  } )
+
+  it( 'binds an object-effector to a thing and a person-effector to a person — never crossed', async () => {
+    const repertoire = new SchemaRepertoire( [ ...INNATE_SCHEMAS, ...externalSchemas( [
+      { name: 'use',   binds: 'object' },
+      { name: 'greet', binds: 'entity' },
+    ] ) ] )
+    const synth = new AffordanceSynthesizer(); synth.attachRepertoire( repertoire )
+    const field = ( ( await synth.react( 0, 1, mixedState(), CTX ) ).commands?.set ?? [] ).filter( ( e: any ) => e.type === 'affordance' )
+    const targetsOf = ( schema: string ) => field.filter( ( e: any ) => e.metadata?.schema === schema ).map( ( e: any ) => e.metadata?.targetEntityId )
+
+    expect( targetsOf( 'use' ) ).toEqual( [ 'axe' ] )     // object-effector → the thing only
+    expect( targetsOf( 'greet' ) ).toEqual( [ 'ada' ] )   // person-effector → the person only
+  } )
+} )


### PR DESCRIPTION
Closes two of the three remaining `CUSTOM_ABILITY_WIRING.md` opens.

## `binds: 'object'` — target a *thing*
An effector can now target a non-sentient known-entity, so the Will can `use`/`pick-up` something in particular — mirroring `binds: 'entity'` for people. (`'thing'` known-entities are already produced by perception — `known.entity.tracker.ts:392`.) The synthesizer's target-binding pass now **matches schema binding to entity kind** (person→sentient, object→thing) and never crosses them. `SchemaBinding` gains `'object'` (only ever `filter`-matched, so no exhaustive switch breaks).

## `tags` — routing
A declaration may carry routing tags, merged with the mandatory `'external'`/`'host'` markers (deduped). A drive-recognised tag (e.g. `'social'`, `'nourishment'`) lets a homeostatic drive lift the ability in the competition via `selection.scoring`'s `driveUrgency`.

```ts
await Will.create({
  effectors: {
    use:    { handler, binds: 'object', description: 'Use the thing in front of you' },
    forage: { handler, tags: ['nourishment'], description: 'Search the area for food' },
  },
})
```

## Tests
`agency.external-abilities` — tag merge/dedup, `binds:'object'` on the schema, and object-effector→thing / person-effector→person never crossed. Full suite **930 pass / 2 skip / 0 fail**, typecheck clean.

Remaining open: runtime repertoire rebuild for post-create `.effector()` (next PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)