### PR TITLE
feat(executive): conscious args for afforded abilities (ideomotor leg)

### DIFF
--- a/src/cognition/faculties/executive.engine/commands.ts
+++ b/src/cognition/faculties/executive.engine/commands.ts
@@ -399,10 +399,15 @@ function resolveKnownEntity( target: string, state: ReadonlySimulationState ): s
 }
 
 /**
- * Turn the executive's imagined communicate actions into `ideomotor.intent` entities
- * (the ideomotor leg). The AffordanceSynthesizer surfaces them as competing reach-out
- * affordances next tick. Refreshed each executive cycle — stale intents the executive
- * no longer imagines are deleted, so a momentary "I'd like to reach out" doesn't linger.
+ * Turn the executive's imagined actions into `ideomotor.intent` entities (the
+ * ideomotor leg). Two kinds are pre-activated: communicate actions (as reach-out
+ * toward the resolved entity) and *currently-afforded host abilities* — an action
+ * whose type names an external affordance in the field, optionally carrying the
+ * `args` the executive consciously supplied (a mind formulating "search the docs
+ * for X" IS the situation providing the argument). The AffordanceSynthesizer
+ * surfaces them as competing candidates next tick — executive intention ENTERS
+ * the competition, it never bypasses it. Refreshed each executive cycle — stale
+ * intents the executive no longer imagines are deleted.
  */
 function buildIdeomotorIntents(
   output:    ExecutiveOutputFull,
@@ -413,16 +418,47 @@ function buildIdeomotorIntents(
   const seen = new Set<string>()
   const priority = clamp01( output.confidence ?? 0.8 )
 
+  // The host abilities currently afforded (source 'external' in the live field) —
+  // the executive can only pre-activate what the situation actually offers.
+  const externalBySchema = new Map<string, string>()
+  for( const e of state.entities.values() ){
+    if( e.type !== 'affordance' ) continue
+    const m = e.metadata as Record<string, unknown> | undefined
+    if( m?.['source'] !== 'external' ) continue
+    const schema = typeof m['schema'] === 'string' ? m['schema'] as string : undefined
+    if( schema ) externalBySchema.set( schema.toLowerCase(), schema )
+  }
+
   for( const action of output.actions ){
-    if( !COMMUNICATE_ACTION_TYPES.has( action.type.toLowerCase() ) ) continue
-    if( !action.target ) continue
-    const keid = resolveKnownEntity( action.target, state )
-    if( !keid || seen.has( keid ) ) continue
-    seen.add( keid )
+    const t = action.type.toLowerCase()
+
+    if( COMMUNICATE_ACTION_TYPES.has( t ) ){
+      if( !action.target ) continue
+      const keid = resolveKnownEntity( action.target, state )
+      if( !keid || seen.has( keid ) ) continue
+      seen.add( keid )
+      set.push({
+        id:   `ideomotor-reach-out-${ keid }`,
+        type: 'ideomotor.intent',
+        metadata: { schema: 'reach-out', targetEntityId: keid, priority, origin: 'executive', tick: footprint.tickObserved },
+      })
+      continue
+    }
+
+    // A host ability the executive imagines enacting, with its conscious args.
+    const schema = externalBySchema.get( t )
+    if( !schema || seen.has( `ability:${ schema }` ) ) continue
+    seen.add( `ability:${ schema }` )
+    const keid = action.target ? resolveKnownEntity( action.target, state ) : undefined
     set.push({
-      id:   `ideomotor-reach-out-${ keid }`,
+      id:   `ideomotor-${ schema }${ keid ? `-${ keid }` : '' }`,
       type: 'ideomotor.intent',
-      metadata: { schema: 'reach-out', targetEntityId: keid, priority, origin: 'executive', tick: footprint.tickObserved },
+      metadata: {
+        schema,
+        ...( keid ? { targetEntityId: keid } : {} ),
+        ...( action.args && typeof action.args === 'object' ? { parameters: action.args } : {} ),
+        priority, origin: 'executive', tick: footprint.tickObserved,
+      },
     })
   }
 

--- a/src/cognition/faculties/executive.engine/prompt.factory.ts
+++ b/src/cognition/faculties/executive.engine/prompt.factory.ts
@@ -344,7 +344,7 @@ ${roleDescription}
 ${consciousnessArchitecture}
 
 ## Output Guidelines
-- **actions**: Choose from effectors you know about. If uncertain, describe what you want to achieve in natural language and your body will try to match it.
+- **actions**: Choose from effectors you know about. If uncertain, describe what you want to achieve in natural language and your body will try to match it. When enacting one of your available abilities that needs specifics (a query, a message, a value), supply them in the action's "args" object — e.g. {"type": "search_docs", "args": {"query": "tick loop design"}, ...}. Your body enacts the ability with exactly those args.
 - **plans**: Include for goals without existing plans or where plans need revision. You may keep multiple plans per goal — set **planId** to act on a specific existing plan (validate/execute/revise/cancel); omit it to draft a new one. Your current plans are listed under "## Active Plans".
 - **newBeliefs**: Extract patterns from experiences visible in your current state. Only record a belief if you can point to a specific observation that supports it — do not infer experiences you have no record of. Set 'evidence' honestly: 'single_observation' (first time noticing), 'recurring_pattern' (seen multiple times), 'strong_pattern' (deeply established).
 - **introspection**: Include when significant events occurred or you notice patterns. When you spot a cognitive bias in your own reasoning, name it in 'identifiedBiases' using its common term where one fits (e.g. overgeneralization, confirmation bias, recency bias) — this lets your self-assessment line up with the patterns your faculties detect on their own.
@@ -647,7 +647,7 @@ Dominance: ${context.affect.dominance.toFixed( 2 )}${context.affect.blends.lengt
     // self-knowledge (things you *can* do), NOT a tool-call menu: the Will still
     // expresses intent in natural language and the agency field enacts the fit.
     const abilitiesBlock = ( context.abilities && context.abilities.length > 0 )
-      ? `## Abilities Available Now\nThings you can do in this situation — express what you want and your body enacts the fit:\n${context.abilities.map( a =>
+      ? `## Abilities Available Now\nThings you can do in this situation — name one as an action's "type" (with "args" for any specifics it needs) and your body enacts it:\n${context.abilities.map( a =>
           `- **${a.name}**${a.target ? ` (toward ${a.target})` : ''}${a.description ? ` — ${a.description}` : ''}`
         ).join( '\n' )}`
       : ''

--- a/src/cognition/faculties/executive.engine/types.ts
+++ b/src/cognition/faculties/executive.engine/types.ts
@@ -8,7 +8,16 @@ import type { PlanStep } from '#cognition/faculties/planning.engine/engine'
 // ── Full executive output ────────────────────────────────────
 
 export interface ExecutiveOutputFull {
-  actions: Array<{ type: string; reasoning: string; expectedOutcome: string; target?: string }>
+  actions: Array<{
+    type: string; reasoning: string; expectedOutcome: string; target?: string
+    /**
+     * Arguments the executive consciously supplies when enacting an ability
+     * that needs them (e.g. a search ability's query). Ride the ideomotor
+     * intent into the affordance competition and, if the action wins, reach
+     * the host handler as the invocation's parameters.
+     */
+    args?: Record<string, unknown>
+  }>
   reasoning: string
   confidence: number
   /** Plans — the executive controls lifecycle via status + action fields */
@@ -140,7 +149,7 @@ export interface ExecutivePlanOutput {
 // ── Minimal output from LLM (before tagged-block parsing) ────
 
 export interface ExecutiveOutputMinimal {
-  actions: Array<{ type: string; reasoning: string; expectedOutcome: string; target?: string }>
+  actions: Array<{ type: string; reasoning: string; expectedOutcome: string; target?: string; args?: Record<string, unknown> }>
   reasoning: string
   confidence: number
 }

--- a/tests/unit/agency.synthesizer.test.ts
+++ b/tests/unit/agency.synthesizer.test.ts
@@ -231,3 +231,23 @@ describe( 'AffordanceSynthesizer — deterministic & transient', () => {
     expect( res.commands?.delete ).toContain( 'affordance-1-orient-orient' )
   })
 })
+
+describe( 'AffordanceSynthesizer — ideomotor parameters passthrough (executive args)', () => {
+  it( 'carries an ideomotor.intent\'s parameters onto the surfaced affordance', async () => {
+    const { externalSchemas } = await import( '#agency/schemas/external' )
+    const { INNATE_SCHEMAS }  = await import( '#agency/schemas/innate' )
+    const synth = new AffordanceSynthesizer( [ ...INNATE_SCHEMAS, ...externalSchemas( [ 'search_docs' ] ) ] )
+    const res   = await synth.react( 0, 1, makeState({
+      metrics:  { 'energy.level': 80 },
+      entities: [
+        { id: 'ideo-search', type: 'ideomotor.intent',
+          metadata: { schema: 'search_docs', priority: 0.9, parameters: { query: 'tick loop design' } } },
+      ],
+    }), CTX )
+
+    const aff = ( res.commands?.set ?? [] ).find( ( e: EntityInput ) =>
+      e.type === 'affordance' && e.metadata?.['schema'] === 'search_docs' && e.metadata?.['source'] === 'ideomotor' )
+    expect( aff ).toBeDefined()
+    expect( aff?.metadata?.['parameters'] ).toEqual( { query: 'tick loop design' } )
+  })
+})

--- a/tests/unit/executive.commands.test.ts
+++ b/tests/unit/executive.commands.test.ts
@@ -241,3 +241,71 @@ describe( 'buildStateCommands — known-entity updates (Phase 2.2)', () => {
     expect( ev?.payload ).toMatchObject( { keid: 'web:42', name: 'Mara', feeling: 0.3 } )
   })
 })
+
+// ── Ideomotor ability leg — executive-supplied args (MCP-effectors groundwork) ──
+// An executive action whose type names a CURRENTLY-AFFORDED host ability becomes an
+// ideomotor.intent carrying the action's conscious `args` as `parameters` — the
+// existing ideomotor pipeline (synthesizer → selector → motor → invocation) then
+// delivers them to the host handler. Only what the field affords can be pre-activated.
+
+function stateWithExternalAffordance( schema: string, extra: Array<{ id: string; type: string; metadata?: Record<string, unknown> }> = [] ): ReadonlySimulationState {
+  const entities = new Map<string, unknown>()
+  entities.set( `aff-${ schema }`, { id: `aff-${ schema }`, type: 'affordance', createdAt: 0, updatedAt: 0,
+    metadata: { schema, source: 'external', available: true } } )
+  for( const e of extra )
+    entities.set( e.id, { ...e, createdAt: 0, updatedAt: 0 } )
+  return { tick: 1, time: 0, entities, metrics: new Map() } as unknown as ReadonlySimulationState
+}
+
+function outputWithAction( action: Record<string, unknown> ): ExecutiveOutputFull {
+  return { actions: [ action ], reasoning: 'r', confidence: 0.8 } as unknown as ExecutiveOutputFull
+}
+
+const ideomotorOf = ( commands: { set?: Array<{ id: string; type: string; metadata?: Record<string, unknown> }> }, schema: string ) =>
+  ( commands.set ?? [] ).find( e => e.type === 'ideomotor.intent' && e.metadata?.['schema'] === schema )
+
+describe( 'buildStateCommands — ideomotor ability leg (executive args)', () => {
+  const run = ( output: ExecutiveOutputFull, state: ReadonlySimulationState ) => {
+    const log = freshLog()
+    return buildStateCommands( output, footprintAt( 1 ), state, makeDeps( log, new ExecutiveSummarizer() ), [] ).commands
+  }
+
+  it( 'pre-activates an afforded ability with the executive\'s conscious args', () => {
+    const commands = run(
+      outputWithAction( { type: 'search_docs', reasoning: 'need the design', expectedOutcome: 'found', args: { query: 'tick loop design' } } ),
+      stateWithExternalAffordance( 'search_docs' ),
+    )
+    const intent = ideomotorOf( commands, 'search_docs' )
+    expect( intent ).toBeDefined()
+    expect( intent?.metadata?.['parameters'] ).toEqual( { query: 'tick loop design' } )
+    expect( intent?.metadata?.['origin'] ).toBe( 'executive' )
+  } )
+
+  it( 'ignores an action naming an ability the field does not currently afford', () => {
+    const commands = run(
+      outputWithAction( { type: 'search_docs', reasoning: 'r', expectedOutcome: 'o', args: { query: 'x' } } ),
+      { tick: 1, time: 0, entities: new Map(), metrics: new Map() } as unknown as ReadonlySimulationState,
+    )
+    expect( ideomotorOf( commands, 'search_docs' ) ).toBeUndefined()
+  } )
+
+  it( 'resolves the action target to a known-entity keid for a targeted ability', () => {
+    const commands = run(
+      outputWithAction( { type: 'give', reasoning: 'r', expectedOutcome: 'o', target: 'Ada' } ),
+      stateWithExternalAffordance( 'give', [
+        { id: 'ke-ada', type: 'known-entity', metadata: { keid: 'ada', kind: 'sentient', name: 'Ada' } },
+      ] ),
+    )
+    expect( ideomotorOf( commands, 'give' )?.metadata?.['targetEntityId'] ).toBe( 'ada' )
+  } )
+
+  it( 'leaves the communicate leg untouched (reach-out still forms from a communicate action)', () => {
+    const commands = run(
+      outputWithAction( { type: 'communicate', reasoning: 'r', expectedOutcome: 'o', target: 'Ada' } ),
+      stateWithExternalAffordance( 'unrelated', [
+        { id: 'ke-ada', type: 'known-entity', metadata: { keid: 'ada', kind: 'sentient', name: 'Ada' } },
+      ] ),
+    )
+    expect( ideomotorOf( commands, 'reach-out' )?.metadata?.['targetEntityId'] ).toBe( 'ada' )
+  } )
+} )


### PR DESCRIPTION
Groundwork for MCP-tools-as-effectors (Seam 1 — Will *employing* external tools). Abilities like "search the docs" are unusable without an argument, and the paradigm rules out LLM form-filling at the motor boundary. The honest seam is the **ideomotor path**: a mind consciously formulating *"I'll search the docs for X"* IS the situation supplying the argument.

## What changes
- Executive actions gain optional **`args`** (the parser already passes parsed actions through untouched — this is typing + consumption).
- `buildIdeomotorIntents` generalizes beyond communicate actions: an action whose type names a **currently-afforded** host ability (source `external` in the live field — the executive can only pre-activate what the situation actually offers) becomes an `ideomotor.intent` carrying `action.args` as `parameters`, plus a resolved target keid when given.
- Those parameters ride the **existing** pipeline with zero new transport: synthesizer's ideomotor leg → affordance → selection/deliberation (candidates keep their params) → invocation → host handler `args`. Intention *enters* the competition; it never bypasses it.
- Prompt: the actions guideline + "Abilities Available Now" section now tell the executive it may supply `"args"` when an ability needs specifics.
- Innate actions are deliberately **not** pre-activated — no behavioral shift for reflect/rest/observe; the behavioral-harness bands hold.

## Tests
Commands leg (args carried onto the intent, unafforded ability ignored, target resolved to keid, communicate leg untouched) + synthesizer parameter passthrough. Full suite **946 pass / 2 skip / 0 fail**, typecheck clean.

Next PR builds on this: `will.useMcpTools(...)` — an MCP client that registers a server's tools as effectors (description → meaning, result → reafference), with the executive supplying their args through this leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)