### PR TITLE
chore: release 0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mindot/will",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "author": "Fabrice <fabrice8@github.com>",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Version bump for the 0.2.0 release — the MCP + effector-model release. Release notes go on the GitHub Release (which triggers the tokenless publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)