### PR TITLE
fix(determinism): close the audition-reply flake — testMode network-embedder guard + conversation replay test

### DIFF
--- a/.TODO/AUDITION_REPLY_DETERMINISM.md
+++ b/.TODO/AUDITION_REPLY_DETERMINISM.md
@@ -1,56 +1,49 @@
 # Audition conversation-reply determinism + reliability gap
 
-**Status:** OPEN — found 2026-07-05 while building the SDK facade (examples/effectors.ts).
-**Severity:** medium — real, but masked in practice (a real executive + real percept
-salience is far more reliable than the mock; the facade itself is correct).
+**Status:** ✅ RESOLVED (2026-07-08). Root cause found, guarded at the engine
+chokepoint, and both done-criteria are now pinned by CI tests.
+**History:** found 2026-07-05 while building the SDK facade (examples/effectors.ts).
 
-## The gap
+## Root cause (measured, not the suspected mechanism)
 
-A conversation reply (`ingestText` → audition facet → outbox message) is **not
-reliably produced under the mock executive**, and its timing is **non-deterministic
-even with a fixed `randomSeed` + fixed clock**:
+The suspected salience/attention race was wrong. The flake was **environment
+bleed**: bun auto-loads the dev `.env`, which carried `WILL_SEMANTIC_RECALL=true`
++ `WILL_EMBEDDING_MODEL=google/…` + a live Google key — so every "mock" Will was
+doing **real network embedding calls inside `buildExecutiveContext`** on the
+facet reasoning path. Wall-clock embed latency (~600–800 ms per context build)
+then jittered the LLM issue tick, which jittered everything downstream:
 
-- Same config (seed 7, fixed clock, mock, `"Hello who are you?"`) across repeated
-  fresh-process runs: one run produced NO reply within 12 s; the next replied at
-  tick 168. Deterministic inputs, non-deterministic output.
-- Reply presence is also sensitive to message *content* (`"Please remember X"` —
-  read as an instruction — suppressed the reply where `"Hello who are you?"` did
-  not) and to identity-prompt wording.
+- reply tick varied run-to-run (measured 123–169 under seed 7);
+- reply CONTENT varied — the mock picks `REPLY_CYCLES[tick % 4]`, so tick
+  jitter selected different canned replies (4 distinct texts across 12 runs);
+- pre-#27, in-flight facets could be reaped mid-chain → the original
+  "no reply at all" failures. (#27 "never reap a busy facet" fixed the loss.)
 
-## Why it matters
+With recall actually off: **8/8 fresh-process runs byte-identical** — reply at
+`ingestTick + 1`, same content, every run. The engine's conversation path was
+already deterministic (report → per-tick pump → CompletionInbox landing); the
+tick-quantization layers were never the problem on this path.
 
-1. **Determinism**: the R2-d replay capstone passes, but it exercises the MASTER
-   executive path. The AUDITION conversation facet appears to retain a
-   wall-clock/scheduler dependency the executive-facet pump (CompletionInbox +
-   per-tick pump, see FACET_REPLAY_DETERMINISM.md) does not cover. If a
-   conversation reply's issue/land tick can vary under a fixed seed, byte-identical
-   replay does not hold for conversational Wills.
-2. **Product reliability**: `say()` should reliably get a reply. Under the mock it
-   is flaky; the concern is whether real-LLM conversation replies are ever
-   similarly starved (e.g. the conversation facet losing an attention/salience race
-   to a background executive cycle or a custom-effector schema).
+## The fix
 
-## Suspected mechanism (unverified)
+1. **Engine guard (`_resolveVectorMemory`, stem/mind.ts):** `testMode` refuses
+   the env-driven NETWORK embedder (logs and runs without vector memory).
+   Explicit adapters and `WILL_VECTOR_MEMORY=mock` stay honored. This kills the
+   `.env`-bleed class at the single chokepoint — it had bitten three times
+   (replay layer-3 masking, the soak test, this flake).
+2. **Conversation replay test** (`tests/integration/replay.conversation.test.ts`)
+   — the R2-d peer for the audition path: scripted `ingest` at a fixed tick,
+   record → re-feed, asserts the reply (content + target + outbox tick) and the
+   FULL state snapshot replay byte-identically. Done-criterion (a).
+3. **Reliability test** (`tests/integration/audition.reply.reliability.test.ts`)
+   — greeting, instruction phrasing, and with a registered effector each reply
+   within a bounded tick budget. Deliberately does NOT override recall env, so
+   it doubles as the end-to-end sentinel for the guard. Done-criterion (b).
 
-The audition facet's reasoning is gated by salience/attention. Under the mock the
-language-percept salience may sit near the trigger threshold, so RNG/timing tips it
-either way. A custom-effector schema in the repertoire made it worse — possibly the
-action competition or attention budget starving the conversation facet.
+## Residual notes
 
-## Fix directions
-
-1. **Trace the audition facet through the tick-quantized pump.** Confirm whether
-   audition facet reasoning launches from `FacetSupervisor.pump()` (deterministic)
-   or still from a raw `report()` path (the layer-3 issue, but for audition).
-2. **Guarantee a language percept crosses the reasoning threshold.** A direct
-   conversation turn should not depend on ambient salience to get a reply — the
-   percept itself should reliably recruit the facet.
-3. **Add a conversation-path replay test** (peer to replay.equivalence) that
-   records+re-feeds a scripted conversation and asserts byte-identical state, so
-   this path is covered, not just the master executive.
-
-## Re-enable / done criteria
-
-A scripted conversation (ingestText → reply) is (a) deterministic under a fixed
-seed across repeated runs, and (b) reliably produces a reply within a bounded tick
-budget regardless of message phrasing or registered effectors.
+- Under a live LLM + live embedder, tick-exact determinism is not a goal —
+  replay-grade audit uses the record/re-feed seam (completion recorder), which
+  the conversation test now covers.
+- The mock's reply-content selection (`tick % 4`) makes content a visible
+  canary for tick jitter — useful; left as-is.

--- a/src/stem/mind.ts
+++ b/src/stem/mind.ts
@@ -340,12 +340,13 @@ export function resolveModelId( provider: LLMProvider, modelTier: ModelTier ): s
 //   WILL_EMBEDDING_DIMENSIONS  — Vector dimensions (default: 1536)
 //   WILL_VECTOR_MEMORY=mock    — Use deterministic mock embedder (dev/test only)
 
-function _resolveVectorMemory(
+export function _resolveVectorMemory(
   willId: string,
   seed: number,
   overrideAdapter?: VectorMemoryAdapter,
   disable?: boolean,
   tokenTracker?: TokenTracker | null,
+  testMode?: boolean,
 ): {
   embedder: InstanceType<typeof OpenAICompatibleEmbedder> | MockEmbedder | null
   vectorMemory: VectorMemoryAdapter | null
@@ -364,6 +365,22 @@ function _resolveVectorMemory(
   // Explicitly disabled — the documented "none" sentinel or recall turned off.
   if( !mockMode && ( rawModel === 'none' || process.env.WILL_SEMANTIC_RECALL === 'false' ) )
     return { embedder: null, vectorMemory: null }
+
+  // testMode promises a deterministic, zero-key, offline mind — but a dev .env
+  // (auto-loaded by bun) can carry WILL_SEMANTIC_RECALL=true + an embedding
+  // model + a live key, silently turning "mock" runs into real network embeds
+  // inside buildExecutiveContext. Wall-clock embed latency then jitters every
+  // downstream tick (reply timing/content under a fixed seed) — the root cause
+  // of the audition-reply determinism flake. An explicit adapter or the
+  // deterministic mock embedder is honored; the env-driven NETWORK embedder is
+  // refused here, at the single chokepoint.
+  if( testMode && !mockMode ){
+    logger.info(
+      `[vector-memory] ${willId}: testMode — ignoring env embedder "${rawModel}" ` +
+      `(live network embeds would break mock determinism; use WILL_VECTOR_MEMORY=mock or pass an adapter)`
+    )
+    return { embedder: null, vectorMemory: null }
+  }
 
   // Resolve endpoint, key and native dimensions. Two forms are supported:
   //   • "provider/model" (e.g. google/gemini-embedding-001) — the base URL and
@@ -640,7 +657,7 @@ function _constructCognition(
   // ── Memory ──────────────────────────────────────────────
   const workingMemory = new WorkingMemory()
 
-  const { embedder, vectorMemory } = _resolveVectorMemory( willId, randomSeed, config.vectorMemoryAdapter, config.disableVectorMemory, tokenTracker )
+  const { embedder, vectorMemory } = _resolveVectorMemory( willId, randomSeed, config.vectorMemoryAdapter, config.disableVectorMemory, tokenTracker, config.testMode )
   const episodicConsolidator = new EpisodicConsolidator( vectorMemory ? { vectorMemory, ...(embedder ? { embedder } : {}) } : {} )
 
   const semanticIntegrator   = new SemanticIntegrator()

--- a/tests/integration/audition.reply.reliability.test.ts
+++ b/tests/integration/audition.reply.reliability.test.ts
@@ -1,0 +1,70 @@
+// ─────────────────────────────────────────────────────────────
+// tests/integration/audition.reply.reliability.test.ts
+// ─────────────────────────────────────────────────────────────
+/**
+ * Done-criterion (b) of .TODO/AUDITION_REPLY_DETERMINISM.md: a mock Will
+ * RELIABLY replies to a direct message within a bounded tick budget —
+ * regardless of phrasing (greeting vs instruction) and of registered
+ * effectors (the original flake's sensitivities).
+ *
+ * Deliberately does NOT force recall off via env: with a dev .env auto-loaded
+ * (WILL_SEMANTIC_RECALL=true + a live embedding key) this test doubles as the
+ * end-to-end sentinel for the testMode network-embedder guard in
+ * _resolveVectorMemory — if the guard regresses, live embeds return, reply
+ * latency blows past the budget, and this fails loudly.
+ */
+
+import { describe, it, expect, afterAll } from 'vitest'
+import { Will } from '#sdk/will'
+import { setLogger, resetLogger } from '#core/logger'
+
+setLogger( { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} } )
+afterAll( () => resetLogger() )
+
+/** Generous CI budget; the healthy path replies ~1 tick after ingest. */
+const REPLY_BUDGET_TICKS = 60
+const WAIT_MS            = 8_000
+
+async function replyLatency( message: string, withEffector: boolean ): Promise<{ replied: boolean; latency: number }> {
+  const will = await Will.create( {
+    name: 'Echo', identity: { prompt: 'I am Echo, a friendly presence.' },
+    llm: 'mock', engineTier: 'standard', tickMs: 10, seed: 7,
+    ...( withEffector ? { effectors: { remember_note: { handler: async () => 'ok', description: 'Store a note' } } } : {} ),
+  } )
+  try {
+    let replyTick = -1
+    const done = new Promise<void>( resolve => {
+      will.stem.addTickListener( will.id, ( _s, tick, outbox ) => {
+        if( replyTick < 0 && outbox.length > 0 ){ replyTick = tick; resolve() }
+      } )
+    } )
+
+    while( will.state().tick < 30 ) await new Promise( r => setTimeout( r, 5 ) )
+    const ingestTick = will.state().tick
+    await will.tell( 'sam', 'Sam', message )
+    await Promise.race( [ done, new Promise( r => setTimeout( r, WAIT_MS ) ) ] )
+
+    return { replied: replyTick >= 0, latency: replyTick >= 0 ? replyTick - ingestTick : -1 }
+  }
+  finally { await will.stop() }
+}
+
+describe( 'Audition reply reliability (mock, bounded tick budget)', () => {
+  it( 'replies to a greeting within budget', async () => {
+    const r = await replyLatency( 'Hello, who are you?', false )
+    expect( r.replied ).toBe( true )
+    expect( r.latency ).toBeLessThanOrEqual( REPLY_BUDGET_TICKS )
+  }, 30_000 )
+
+  it( 'replies to instruction-shaped phrasing within budget (the original suppressor)', async () => {
+    const r = await replyLatency( 'Please remember that my favorite color is blue.', false )
+    expect( r.replied ).toBe( true )
+    expect( r.latency ).toBeLessThanOrEqual( REPLY_BUDGET_TICKS )
+  }, 30_000 )
+
+  it( 'replies with a custom effector registered within budget (the original starver)', async () => {
+    const r = await replyLatency( 'Hello, who are you?', true )
+    expect( r.replied ).toBe( true )
+    expect( r.latency ).toBeLessThanOrEqual( REPLY_BUDGET_TICKS )
+  }, 30_000 )
+} )

--- a/tests/integration/replay.conversation.test.ts
+++ b/tests/integration/replay.conversation.test.ts
@@ -1,0 +1,215 @@
+// ─────────────────────────────────────────────────────────────
+// tests/integration/replay.conversation.test.ts
+// ─────────────────────────────────────────────────────────────
+/**
+ * Conversation-path replay equivalence — the peer to replay.equivalence (R2-d),
+ * which exercises only the MASTER executive. Here a scripted conversation
+ * (auditionEngine.ingest → conversation facet → [REPLY_TEXT] → outbox) runs
+ * with the LLM in the loop:
+ *
+ *   Run A (record)  — mock LLM, ingest "Hello…" at a fixed tick, run N ticks;
+ *                     a recorder captures every completion.
+ *   Run B (re-feed) — fresh mind, same seed, same scripted ingest; mock OFF,
+ *                     recorded completions served via RecordedCompletionSource.
+ *
+ * Assertions: the REPLY itself is byte-identical (content + target + the sim
+ * tick it entered the outbox), and the full state snapshot matches metric-for-
+ * metric, entity-for-entity. This closes fix-direction 3 of
+ * .TODO/AUDITION_REPLY_DETERMINISM.md: conversational Wills replay, not just
+ * background cognition.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest'
+import { assembleMind, type WillConfig } from '#stem/mind'
+import {
+  setCompletionRecorder, clearCompletionRecorder,
+  setCompletionSource, clearCompletionSource,
+  RecordedCompletionSource,
+  type LLMCompletionRecord,
+  type LLMCompletionSource,
+} from '#core/completion.recorder'
+import type { SimulationEntity, SimulationState } from '#core/types'
+import type { OutboxMessage } from '#types'
+import { setLogger, resetLogger } from '#core/logger'
+
+setLogger( { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} } )
+
+const WILL_ID     = 'will-replay-conversation'
+const SEED        = 424242
+const TICKS       = 40
+const INGEST_TICK = 10
+const DELTA_MS    = 50
+const MESSAGE     = 'Hello, who are you?'
+
+function makeConfig( testMode: boolean ): WillConfig {
+  return {
+    id:               WILL_ID,
+    name:             'ReplayEcho',
+    profile:          null,
+    identity: {
+      prompt: 'I am ReplayEcho, a deterministic conversational test mind.',
+      values: [ 'honesty' ],
+      traits: { openness: 0.7 },
+      style:  'concise',
+    },
+    engineTier:        'standard',
+    modelTier:         'haiku',
+    persistentMemory:  false,
+    snapshotInterval:  999_999,
+    tickIntervalMs:    0,
+    randomSeed:        SEED,
+    executiveInterval: 5,
+    clock:             { fixedDeltaMs: DELTA_MS, startTime: 0 },
+    // The conversation surface: listen (inbound) + talk/text (the reply path).
+    allowedGenericEffectors: [ 'listen', 'talk', 'text' ],
+    testMode,
+  }
+}
+
+/** Wall-clock provenance stripped (same rule as the R2-d capstone). */
+function comparable( e: SimulationEntity ): Record<string, unknown> {
+  const { createdAt: _createdAt, ...rest } = e
+  return rest
+}
+
+/** The reply facts that must replay byte-identically (wall-clock ids/times aside). */
+function replyFacts( rows: OutboxMessage[] ): Array<Record<string, unknown>> {
+  return rows.map( r => ( {
+    to:      r.targetEntityId,
+    content: r.content,
+    via:     r.effectorName,
+    tick:    r.createdAtTick,
+  } ) )
+}
+
+class CountingSource implements LLMCompletionSource {
+  consumed = 0
+  constructor( private readonly _inner: LLMCompletionSource ){}
+  nextCompletion( tick: number, systemPrompt: string, userMessage: string ): LLMCompletionRecord {
+    const record = this._inner.nextCompletion( tick, systemPrompt, userMessage ) as LLMCompletionRecord
+    this.consumed++
+    return record
+  }
+}
+
+// Offline discipline (belt) — the testMode network-embedder guard in
+// _resolveVectorMemory is the suspenders; both runs must never touch a network.
+const ENV_OVERRIDES: Record<string, string | undefined> = {
+  WILL_SUMMARY_INTERVAL:        '100000',
+  WILL_VECTOR_MEMORY:           '',
+  WILL_SEMANTIC_RECALL:         'false',
+  WILL_EMBEDDING_MODEL:         'none',
+  WILL_EMBEDDING_API_KEY:       undefined,
+  GOOGLE_GENERATIVE_AI_API_KEY: undefined,
+  WILL_LLM_API_KEY:             undefined,
+  ANTHROPIC_API_KEY:            undefined,
+}
+const _savedEnv: Record<string, string | undefined> = {}
+
+describe( 'Replay equivalence — scripted conversation (audition path)', () => {
+  beforeAll( () => {
+    for( const key of Object.keys( ENV_OVERRIDES ) ){
+      _savedEnv[ key ] = process.env[ key ]
+      const value = ENV_OVERRIDES[ key ]
+      if( value === undefined ) delete process.env[ key ]
+      else process.env[ key ] = value
+    }
+  })
+
+  afterAll( () => {
+    for( const key of Object.keys( ENV_OVERRIDES ) ){
+      const value = _savedEnv[ key ]
+      if( value === undefined ) delete process.env[ key ]
+      else process.env[ key ] = value
+    }
+    resetLogger()
+  })
+
+  afterEach( () => {
+    clearCompletionRecorder( WILL_ID )
+    clearCompletionSource( WILL_ID )
+  })
+
+  /** Per-tick quiescence drain — same discipline as the R2-d capstone. */
+  async function stepSettled(
+    sim:     { step: ( n: number ) => Promise<unknown> | unknown },
+    ticks:   number,
+    counter: () => number,
+  ): Promise<void> {
+    for( let t = 0; t < ticks; t++ ){
+      await sim.step( 1 )
+      let last = -1, quiet = 0
+      for( let r = 0; r < 400 && quiet < 20; r++ ){
+        await new Promise( res => setTimeout( res, 5 ) )
+        const now = counter()
+        quiet = now === last ? quiet + 1 : 0
+        last  = now
+      }
+    }
+  }
+
+  /**
+   * One scripted conversation run: step to INGEST_TICK, deliver the message
+   * (NOT awaited — ingest blocks on the turn, which resolves only as later
+   * ticks pump the facet and land the decision), then step to TICKS.
+   */
+  async function run( testMode: boolean, counter: () => number ): Promise<{
+    snap: SimulationState; outbox: OutboxMessage[]; turn: Promise<void>
+  }> {
+    const { simulation, cognition, outbox } = assembleMind( WILL_ID, makeConfig( testMode ) )
+    await stepSettled( simulation, INGEST_TICK, counter )
+
+    const turn = cognition.auditionEngine.ingest( {
+      kind: 'text', entityId: 'sam', threadId: 't1', content: MESSAGE, speakerName: 'Sam',
+    } as never ) as unknown as Promise<void>
+
+    await stepSettled( simulation, TICKS - INGEST_TICK, counter )
+    return { snap: simulation.stateManager.snapshot(), outbox, turn }
+  }
+
+  it( 'replays a conversation byte-identically — reply content, reply tick, full state', async () => {
+    // ── Run A: record ──────────────────────────────────────────
+    const recordsA: LLMCompletionRecord[] = []
+    setCompletionRecorder( WILL_ID, { recordCompletion: r => recordsA.push({ ...r }) } )
+    const a = await run( true, () => recordsA.length )
+    clearCompletionRecorder( WILL_ID )
+
+    expect( recordsA.length ).toBeGreaterThan( 0 )        // the LLM was in the loop
+    expect( a.outbox.length ).toBeGreaterThan( 0 )        // and the Will actually replied
+    await a.turn                                          // turn resolved (no timeout leak)
+
+    // ── Run B: re-feed ─────────────────────────────────────────
+    const source = new CountingSource( new RecordedCompletionSource( recordsA ) )
+    setCompletionSource( WILL_ID, source )
+    const b = await run( false, () => source.consumed )
+    clearCompletionSource( WILL_ID )
+    await b.turn
+
+    // Every recorded completion re-fed exactly once — no live call, no divergence.
+    expect( source.consumed ).toBe( recordsA.length )
+
+    // ── The reply replays byte-identically ─────────────────────
+    expect( replyFacts( b.outbox ) ).toEqual( replyFacts( a.outbox ) )
+
+    // ── Clock ──────────────────────────────────────────────────
+    expect( b.snap.tick ).toBe( a.snap.tick )
+    expect( b.snap.time ).toBe( a.snap.time )
+
+    // ── Full metric equivalence ────────────────────────────────
+    const metricKeys = new Set([ ...a.snap.metrics.keys(), ...b.snap.metrics.keys() ])
+    for( const key of metricKeys )
+      expect( b.snap.metrics.get( key ), `metric "${key}" diverged on replay` )
+        .toBe( a.snap.metrics.get( key ) )
+
+    // ── Full entity equivalence ────────────────────────────────
+    expect( b.snap.entities.size ).toBe( a.snap.entities.size )
+    const entityIds = new Set([ ...a.snap.entities.keys(), ...b.snap.entities.keys() ])
+    for( const id of entityIds ){
+      const ea = a.snap.entities.get( id )
+      const eb = b.snap.entities.get( id )
+      expect( eb, `entity "${id}" missing on replay` ).toBeDefined()
+      expect( ea, `entity "${id}" absent from run A` ).toBeDefined()
+      expect( comparable( eb! ), `entity "${id}" diverged on replay` ).toEqual( comparable( ea! ) )
+    }
+  }, 180_000 )
+})

--- a/tests/unit/vector.testmode-guard.test.ts
+++ b/tests/unit/vector.testmode-guard.test.ts
@@ -1,0 +1,67 @@
+// ─────────────────────────────────────────────────────────────
+// tests/unit/vector.testmode-guard.test.ts
+// ─────────────────────────────────────────────────────────────
+/**
+ * testMode must never construct the env-driven NETWORK embedder. A dev .env
+ * (auto-loaded by bun) carrying WILL_SEMANTIC_RECALL=true + an embedding model
+ * + a live key silently turned "mock" runs into real network embeds inside
+ * buildExecutiveContext — wall-clock latency that jittered reply timing and
+ * content under a fixed seed (the audition-reply determinism flake, and the
+ * same hole that masked replay layer 3). Explicit adapters and the
+ * deterministic mock embedder stay honored.
+ */
+
+import { describe, it, expect, beforeEach, afterAll } from 'vitest'
+import { _resolveVectorMemory } from '#stem/mind'
+import { setLogger, resetLogger } from '#core/logger'
+
+setLogger( { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} } )
+afterAll( () => resetLogger() )
+
+const ENV_KEYS = [ 'WILL_VECTOR_MEMORY', 'WILL_EMBEDDING_MODEL', 'WILL_EMBEDDING_API_KEY', 'WILL_SEMANTIC_RECALL', 'GOOGLE_GENERATIVE_AI_API_KEY' ]
+const saved: Record<string, string | undefined> = {}
+for( const k of ENV_KEYS ) saved[ k ] = process.env[ k ]
+afterAll( () => {
+  for( const k of ENV_KEYS ){
+    if( saved[ k ] === undefined ) delete process.env[ k ]
+    else process.env[ k ] = saved[ k ]
+  }
+} )
+
+/** The dev-.env bleed shape: recall on, network embedder model, live-looking key. */
+function armNetworkEmbedderEnv(): void {
+  process.env.WILL_SEMANTIC_RECALL = 'true'
+  process.env.WILL_EMBEDDING_MODEL = 'google/gemini-embedding-001'
+  process.env.GOOGLE_GENERATIVE_AI_API_KEY = 'fake-key-for-guard-test'
+  delete process.env.WILL_VECTOR_MEMORY
+  delete process.env.WILL_EMBEDDING_API_KEY
+}
+
+describe( '_resolveVectorMemory — testMode network-embedder guard', () => {
+  beforeEach( armNetworkEmbedderEnv )
+
+  it( 'testMode refuses the env-driven network embedder (returns no vector memory)', () => {
+    const r = _resolveVectorMemory( 'w1', 1, undefined, undefined, null, true )
+    expect( r.embedder ).toBeNull()
+    expect( r.vectorMemory ).toBeNull()
+  } )
+
+  it( 'live mode (testMode off) still builds the env-driven embedder', () => {
+    const r = _resolveVectorMemory( 'w2', 1, undefined, undefined, null, false )
+    expect( r.embedder ).not.toBeNull()
+    expect( r.vectorMemory ).not.toBeNull()
+  } )
+
+  it( 'testMode + WILL_VECTOR_MEMORY=mock keeps the deterministic mock embedder', () => {
+    process.env.WILL_VECTOR_MEMORY = 'mock'
+    const r = _resolveVectorMemory( 'w3', 1, undefined, undefined, null, true )
+    expect( r.embedder ).not.toBeNull()
+    expect( r.vectorMemory ).not.toBeNull()
+  } )
+
+  it( 'testMode + an explicit adapter is honored (caller owns determinism)', () => {
+    const adapter = { store: async () => {}, query: async () => [] } as never
+    const r = _resolveVectorMemory( 'w4', 1, adapter, undefined, null, true )
+    expect( r.vectorMemory ).toBe( adapter )
+  } )
+} )


### PR DESCRIPTION
Resolves `.TODO/AUDITION_REPLY_DETERMINISM.md` — the last open engine-debt item, and the one standing between "mostly deterministic" and **auditor-grade conversational replay**.

## The root cause was not the suspected mechanism
The TODO suspected a salience/attention race. Measurement found **environment bleed**: bun auto-loads the dev `.env` (`WILL_SEMANTIC_RECALL=true` + a google embedding model + a live key), so every "mock" Will was doing **real network embeds inside `buildExecutiveContext`** on the facet reasoning path. ~600–800 ms of wall-clock per context build jittered the LLM issue tick, which jittered everything visible:
- reply tick varied 123–169 under a fixed seed;
- reply **content** varied — the mock picks `REPLY_CYCLES[tick % 4]`, so tick jitter selected different canned replies;
- pre-#27, the in-flight facet could be reaped → the original "no reply at all" cases.

Control experiment: with recall actually off, **8/8 fresh-process runs byte-identical** — reply at `ingestTick + 1`, same content, every run. The conversation path was already deterministic; the tick-quantization layers were never the problem here.

## The fix
- **`_resolveVectorMemory` testMode guard** — a testMode Will refuses the env-driven **network** embedder (explicit adapters and `WILL_VECTOR_MEMORY=mock` stay honored). One chokepoint kills the `.env`-bleed class that has now bitten three times (layer-3 masking, the soak test, this flake).
- **`replay.conversation.test.ts`** — the R2-d capstone's missing peer: a scripted `ingest` at a fixed tick, record → re-feed, asserting the reply (content + target + outbox tick) and the **full state snapshot** replay byte-identically (790 assertions). Done-criterion (a): **conversational Wills now replay, not just background cognition.**
- **`audition.reply.reliability.test.ts`** — greeting, instruction-shaped phrasing, and with-a-registered-effector each reply within a bounded tick budget. Deliberately does **not** override recall env — with a dev `.env` present it is the end-to-end sentinel: if the guard regresses, live embeds return and this fails loudly. Done-criterion (b).
- **`vector.testmode-guard.test.ts`** — the guard matrix (refuse network, keep mock embedder, keep explicit adapter, live mode unaffected).

TODO doc updated to RESOLVED with the measured root cause. Full suite **968 pass / 2 skip / 0 fail**, typecheck clean.

With this merged, the replay-audit story (the EU-wedge lever, and the durable differentiation vs. attest-only accountability products) has no known gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)