### PR TITLE
docs: Discord channel vars in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,3 +47,14 @@ WILL_SNAPSHOT_MAX_MEMORY=500
 WILL_SUMMARY_INTERVAL=10	# Orbital calls between summaries
 WILL_SUMMARY_BUFFER_SIZE=12	# Reasoning passes kept in buffer
 WILL_CONVERSATION_HISTORY=50	# lastMessages for conversation threads
+
+# ── Discord channel (`will discord` — see docs/discord.md) ────
+# Bot token from https://discord.com/developers/applications
+# (enable the Message Content intent, then invite the bot).
+DISCORD_BOT_TOKEN=
+# Comma-separated channel ids the Will inhabits (unset = all it can see)
+# WILL_DISCORD_CHANNELS=123456789012345678,234567890123456789
+# Perceive guild messages only when @mentioned — DMs always perceived
+# WILL_DISCORD_MENTION_ONLY=false
+# Fallback channel id for utterances with no reachable addressee
+# WILL_DISCORD_HOME_CHANNEL=


### PR DESCRIPTION
Follow-up to #47 — `will discord`'s env (`DISCORD_BOT_TOKEN`, `WILL_DISCORD_CHANNELS`, `WILL_DISCORD_MENTION_ONLY`, `WILL_DISCORD_HOME_CHANNEL`) was documented in README + docs/discord.md but missing from `.env.example`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)