### PR TITLE
docs: move the Discord guide to docs/channels/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /node_modules
 /build
 /data
+/.will
 
 .env
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
   utterances route via a durable roster (last shared channel → DM → home
   channel). New `@mindot/will/discord` subpath export (`connectDiscord`);
   `discord.js` ships as an optionalDependency and is imported lazily. Docs:
-  `docs/discord.md`; example: `examples/discord.ts`.
+  `docs/channels/discord.md`; example: `examples/discord.ts`.
 
 - **Deterministic replay now holds end-to-end with the LLM in the loop** — the
   R2-d capstone (record a run's completions → re-feed into a fresh same-seed

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ ANTHROPIC_API_KEY=sk-ant-… npx -y @mindot/will discord
 
 No command prefix, no forced replies. It perceives the rooms it can see (salience-scored — perceiving costs no LLM call), **decides for itself when to speak** (silence is a valid outcome), learns people's names as *learned* knowledge (`discord:<userId>` is one entity across servers), keeps each channel as its own conversation thread, and **can message first** — proactive utterances route to the addressee's last shared channel, then their DM, then `WILL_DISCORD_HOME_CHANNEL`. On shutdown it hibernates to its PMA and returns as the same self, still knowing everyone.
 
-Scope it with `WILL_DISCORD_CHANNELS` (id allowlist) and `WILL_DISCORD_MENTION_ONLY` for busy servers. The bridge grants no tools — it is a mouth and ears, not hands; abilities stay explicit (effectors / MCP). Setup + SDK embedding (`import { connectDiscord } from '@mindot/will/discord'`): [docs/discord.md](docs/discord.md) · runnable: [`examples/discord.ts`](examples/discord.ts).
+Scope it with `WILL_DISCORD_CHANNELS` (id allowlist) and `WILL_DISCORD_MENTION_ONLY` for busy servers. The bridge grants no tools — it is a mouth and ears, not hands; abilities stay explicit (effectors / MCP). Setup + SDK embedding (`import { connectDiscord } from '@mindot/will/discord'`): [docs/channels/discord.md](docs/channels/discord.md) · runnable: [`examples/discord.ts`](examples/discord.ts).
 
 ### The MCP server — a persistent mind in Claude Desktop / Claude Code
 
@@ -800,7 +800,7 @@ cd will && bun run build
 | `WILL_EMBEDDING_MODEL` | `text-embedding-3-small` *(when keyed)* | Embedding model for episodic recall; `none` disables |
 | `WILL_EMBEDDING_URL` | *(provider default)* | Base URL for an OpenAI-compatible embedding endpoint |
 | `WILL_TRANSPORT` | `off` | Delivery mode used by the host: `off` (outbox polling) · `stream` (in-process) · `socketio` (peer) |
-| `DISCORD_BOT_TOKEN` | — | Bot token for `will discord` (see [docs/discord.md](docs/discord.md)) |
+| `DISCORD_BOT_TOKEN` | — | Bot token for `will discord` (see [docs/channels/discord.md](docs/channels/discord.md)) |
 | `WILL_DISCORD_CHANNELS` | *(all visible)* | Comma-separated channel ids the Will inhabits |
 | `WILL_DISCORD_MENTION_ONLY` | `false` | Perceive guild messages only when @mentioned (DMs always perceived) |
 | `WILL_DISCORD_HOME_CHANNEL` | — | Fallback channel for utterances with no reachable addressee |

--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -43,7 +43,7 @@ relationships — on the next start. Who-is-reachable-where survives too
 
 ## Configuration
 
-All the [shared host env](../README.md#configuration-reference) applies
+All the [shared host env](../../README.md#configuration-reference) applies
 (`WILL_NAME`, `WILL_IDENTITY`, `WILL_LLM_MODEL`, `WILL_TICK_MS`, `WILL_PMA_PATH`, …), plus:
 
 | Variable | Default | Description |
@@ -70,14 +70,14 @@ await bridge.start()
 // … later: await bridge.close()   (the Will keeps ticking — it only loses this surface)
 ```
 
-Runnable: [`examples/discord.ts`](../examples/discord.ts). `discord.js` ships as
+Runnable: [`examples/discord.ts`](../../examples/discord.ts). `discord.js` ships as
 an `optionalDependency`; if your install omitted optionals, `bun add discord.js`.
 
 ## Operator notes
 
 - **Perception scope = attack surface.** The bridge grants no tools and runs no
   commands; the Will can only *say things* here. Abilities come separately (and
-  explicitly) via effectors or [MCP tools](../README.md#employing-mcp-tools--the-mind-gets-abilities).
+  explicitly) via effectors or [MCP tools](../../README.md#employing-mcp-tools--the-mind-gets-abilities).
 - **Busy servers:** start with `WILL_DISCORD_CHANNELS` scoped to one or two
   rooms. Perceiving is cheap (no LLM per message), but attention is finite —
   a firehose crowds out what matters.

--- a/examples/discord.ts
+++ b/examples/discord.ts
@@ -4,7 +4,7 @@
 //
 //   DISCORD_BOT_TOKEN=…  ANTHROPIC_API_KEY=sk-ant-…  bun run examples/discord.ts
 //
-// Setup (once, ~90s): docs/discord.md — create a bot, enable the Message
+// Setup (once, ~90s): docs/channels/discord.md — create a bot, enable the Message
 // Content intent, invite it. Then run this. The Will perceives the rooms it
 // can see, replies when IT decides to, remembers people across restarts
 // (Ctrl-C hibernates it to ./.will/), and may message first.
@@ -21,7 +21,7 @@ setLogger( { debug: () => {}, info: () => {}, warn: () => {}, error: console.err
 
 const token = process.env.DISCORD_BOT_TOKEN
 if( !token ){
-  console.error( 'DISCORD_BOT_TOKEN is required — see docs/discord.md for the 90-second setup.' )
+  console.error( 'DISCORD_BOT_TOKEN is required — see docs/channels/discord.md for the 90-second setup.' )
   process.exit( 2 )
 }
 


### PR DESCRIPTION
Finishes a directory move started locally: `docs/discord.md` → `docs/channels/discord.md`, so the bridge docs mirror `src/channels/` before a second bridge lands.

Pure move + link hygiene:
- the guide's own relative links follow the new depth (`../README.md` → `../../README.md`, same for `examples/discord.ts`)
- the five inbound references updated: README ×2 (quickstart section + env table), CHANGELOG, `examples/discord.ts` ×2 (header comment + the missing-token error message a user actually reads)
- every link target and anchor verified to resolve

Also gitignores `/.will` — the CLI hosts' default PMA path (`.will/<name>.pma.json`). Running `will discord` from a checkout currently leaves a mind artifact as a stray untracked file.

Git tracked the move as a rename (93% similarity), so the diff stays reviewable. Typecheck clean, channel tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)