### PR TITLE
release: 0.4.0 — a mind in your Discord server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.4.0 — 2026-07-15 · a mind in your Discord server
+
+The first **channel bridge**: `npx -y @mindot/will discord` puts a persistent
+mind in a server where people already are — it perceives the room, decides for
+itself when to speak, learns everyone, and comes back as the same self.
+
 - **First-run UX: a broken LLM now fails at boot, not into silence.** The hosts
   ping the executive's provider before raising a mind: a bad key, an empty
   balance, or an unknown model exits with the provider's own reason instead of

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mindot/will",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": "Fabrice <fabrice8@github.com>",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Cuts `Unreleased` into **0.4.0**.

## What ships

- **`will discord`** — the first channel bridge (#47, #49): one command puts a persistent mind in a server. New `@mindot/will/discord` subpath export.
- **Boot-time LLM preflight** (#50) — a dead key or empty balance now exits with the provider's reason instead of booting a Will that perceives and can never speak.
- **Deterministic replay end-to-end with the LLM in the loop** (R2-d capstone, pre-existing in Unreleased).
- `.env.example` Discord vars (#48).

## Release-gate checks

Ran exactly what `publish.yml` will run:

- `bun install --frozen-lockfile` against a standalone copy (no workspace root) ✓ — the version bump doesn't stale `bun.lock` (it records the workspace name, not its version)
- `prepublishOnly` chain — typecheck ✓ · `bun test` **993 pass / 0 fail** ✓ · build ✓
- `npm pack --dry-run` confirms the new surface actually ships: `dist/channels/discord.{js,d.ts}` + `src/channels/*` — 197 files, 2.5 MB, `@mindot/will@0.4.0` ✓

## After merge

Publishing needs a **published GitHub Release** — `publish.yml` triggers on `release: [published]`, not on a push to main, so merging this alone ships nothing. Suggested: tag `v0.4.0`, title *"v0.4.0 — a mind in your Discord server"*, matching the v0.2.0/v0.3.0 pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)