### PR TITLE
release: 0.5.0 — WhatsApp, and a choice of executive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## 0.5.0 — 2026-07-15 · WhatsApp, and a choice of executive
+
+The second channel bridge — `npx -y @mindot/will whatsapp`, QR-pair and go —
+and a second production LLM provider: GLM-5.2 over Z.ai's Anthropic-compatible
+endpoint, at roughly half Sonnet's rate for an always-on mind.
+
 - **`will whatsapp` — a persistent mind on WhatsApp** (second channel bridge).
   QR-pairs as a linked device (Baileys); credentials persist next to the PMA so
   later runs reconnect silently. Every author is a learned entity
@@ -19,7 +25,8 @@
   real Anthropic-compatible endpoint, so GLM rides will's Anthropic wire rather
   than the non-streaming OpenAI scaffold: it gets token streaming, the TTFT
   deadline, prompt-cache breakpoints and structured output — full parity, the
-  second production provider. Defaults to `https://api.z.ai/api/anthropic` and
+  second production provider. Defaults to `https://api.z.ai/api/anthropic/v1`
+  (the `/v1` is required — verified against the live endpoint) and
   model `glm-5.2` (pin `glm-5.2[1m]` for the 1M context); `ZAI_API_KEY` alone
   selects it; `WILL_LLM_BASE_URL` points the same provider at any other
   Anthropic-compatible gateway. Priced in the token tracker at $1.40/$4.40 per

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mindot/will",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": "Fabrice <fabrice8@github.com>",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Cuts `Unreleased` into **0.5.0**.

## What ships

- **`will whatsapp`** — second channel bridge (#53): QR-pair a linked device, persistent mind on WhatsApp. Unofficial protocol; the guide leads with the ban-risk warning.
- **GLM-5.2 (Z.ai)** as the second production provider (#52): `ZAI_API_KEY` alone selects it; Anthropic wire, streaming, $1.40/$4.40 pricing. Plus the two latent fixes (provider-derived default model, provider-named wire errors).
- Discord guide names `ZAI_API_KEY`/GLM as the other executive key.

## Release-gate checks (publish.yml's own steps, run ahead)

- `bun install --frozen-lockfile` against a standalone copy, fresh cache ✓ (first attempt hit a corrupted local bun cache — `IntegrityCheckFailed` on a tarball extract, not a lockfile mismatch)
- `prepublishOnly` chain: typecheck ✓ · **1015 pass / 0 fail** ✓ · build ✓
- `npm pack --dry-run`: `dist/channels/whatsapp.{js,d.ts}` + `src/channels/whatsapp.ts` in the tarball, 202 files, `@mindot/will@0.5.0` ✓

## After merge

Tag `v0.5.0` + publish the GitHub Release (the human gate) → OIDC trusted publishing ships it to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)