### PR TITLE
feat(policy): P2 — refusal teaches availability, not incompetence

### DIFF
--- a/.TODO/POLICY_REAFFERENCE.md
+++ b/.TODO/POLICY_REAFFERENCE.md
@@ -270,17 +270,49 @@ the wrong lesson — forbidden ≠ unskilled. P2 gives the ack a discriminated
 `refused` marker and routes it to affordance AVAILABILITY instead of `LearnedSkill`
 competence.
 
-### P2 — Refusal teaches availability, not incompetence
-- [ ] ReafferenceEngine distinguishes a refused outcome from a failed one
-      (a discriminated field on the ack, not a magic `outcomeQuality`).
-- [ ] Refusal updates a **availability prior** keyed by `(schema, paramsKey)`;
-      it must **not** touch `LearnedSkill` value/habit/param-priors.
-- [ ] AffordanceSynthesizer reads availability when fielding; slow recovery
-      permits re-probe (pick the constant with the same care as
-      `CONSEQUENCE_TTL_TICKS`).
-- [ ] Tests: repeated refusal suppresses fielding; competence for the same
-      schema is unchanged; recovery re-fields after N ticks; a *failure* still
-      moves competence normally (no cross-contamination).
+### P2 — Refusal teaches availability, not incompetence ⟶ done (2026-07-21)
+- [x] Refused outcomes carry a discriminated `refused: true` + `finality`
+      marker (`reconcile.learning.ts` `HostAckResult`; stamped by
+      `reconcileInvocation`; set by `applyPolicyOutcomes`). NOT a magic
+      `outcomeQuality`.
+- [x] The **availability layer** lives in `SchemaRepertoire`, strictly apart from
+      `LearnedSkill`: `_availability` map, `recordRefusal(schema, finality, tick)`,
+      `availabilityOf(schema)`, recovery folded into `decay()`, mirrored to
+      `agency.availability` state entities (`availabilityEntities()` /
+      `restoreAvailability()`). Multiplicative cut — **class 0.50, instance 0.12**
+      — floored at 0.05 (never zero, re-probe always possible); slow recovery
+      (0.02/decay) climbs back and the entry is dropped at full recovery, so a
+      long-ago-refused Will returns to the byte-identical quiet path.
+- [x] `ReafferenceEngine`: a `refused` outcome routes to `recordRefusal` and
+      **stops** — it never touches competence (no `recordOutcome`, no discovery,
+      no proceduralization) — while still freeing the awaiting intent and
+      signalling a refused plan step unsuccessful so the plan doesn't hang. Emits
+      `agency.refused.count` only when it fired (quiet path silent).
+- [x] `scoreAffordance` damps a **positive** activation by `availability` and
+      never flips a negative one — a refused ability competes weakly but is never
+      removed from the field, so re-probe survives and recovers with availability.
+      `AffordanceSynthesizer._build` sets `availability` only when `< 1` (omitted
+      otherwise ⇒ affordance field byte-identical for a never-refused Will);
+      `restoreAvailability` rehydrates it alongside composites.
+- [x] **Scope decision (recorded):** P2 keys availability by **schema**, not
+      `(schema, paramsKey)`. At fielding time the Will hasn't bound params yet, so
+      instance-level *envelope narrowing* can only bite at selection time — a
+      distinct, later mechanism. P2 honours class-vs-instance via cut MAGNITUDE
+      (class suppresses the ability; instance barely dents it and recovers fast),
+      which is the fielding-time-implementable half. Per-params gating is the
+      deferred follow-up.
+- [x] Tests (`tests/unit/policy.availability.test.ts`, 11): class-hard vs
+      instance-light, compounding-but-never-zero, monotone recovery + drop,
+      mirror/restore; refusal dents availability + leaves `LearnedSkill`
+      undefined; a genuine failure still records competence + leaves availability
+      at 1; refusal metric only when fired; activation damped-but-positive,
+      byte-identical when absent, recovered restores full weight. Full suite
+      **1139 passed / 2 skipped (171 files)**, replay-equivalence green. Typecheck clean.
+
+**The three verbs, now demonstrable.** Gated (P0), and a mind that *learns the
+shape of its own permissions* rather than re-probing the wall (P1+P2). What
+remains is refinement, not foundation: P3 (refusal as rupture), P4 (escalate as
+speech act), P5 (HELM adapter), and the deferred per-params envelope narrowing.
 
 ### P3 — Refusal as rupture (reuse P4 machinery)
 - [ ] Map `severity` → rupture. At/above `RUPTURE_REVOKE_GATE` (0.7) write the

--- a/src/cognition/agency/engines/affordance.synthesizer.ts
+++ b/src/cognition/agency/engines/affordance.synthesizer.ts
@@ -103,6 +103,9 @@ export class AffordanceSynthesizer implements CognitiveEngine {
     // means the executor, which ticks later in the SAME tick, sees a whole
     // repertoire and can expand a restored mid-flight macro. Idempotent.
     this._repertoire?.restoreComposites( state.entities )
+    // Availability entries (P2) rehydrate the same way, so a restored Will keeps
+    // its learned suppressions instead of re-probing forbidden abilities.
+    this._repertoire?.restoreAvailability( state.entities )
 
     const schemas   = this._repertoire?.schemas() ?? this._schemas
     const skills    = this._skills?.() ?? this._repertoire?.skills() ?? null
@@ -306,6 +309,10 @@ export class AffordanceSynthesizer implements CognitiveEngine {
   ): Affordance {
     const skill = skills?.get( schema.id )
 
+    // Policy availability (P2): omitted when fully available (1), so a never-refused
+    // Will's affordance field is byte-identical. Present only once a refusal dented it.
+    const availability = this._repertoire?.availabilityOf( schema.id ) ?? 1
+
     // Learned value if known, else the schema's intrinsic prior mapped to 0..1.
     const expectedReward = skill?.valueEstimate ?? clamp01( ( ( schema.baseValence ?? 0 ) + 1 ) / 2 )
     const expectedValence = schema.baseValence ?? valence
@@ -333,6 +340,7 @@ export class AffordanceSynthesizer implements CognitiveEngine {
       available:       this._available( schema.preconditions, ( k ) => metric( state, k, 0 ) ),
       tags:            schema.tags ?? [],
       ...( schema.description ? { description: schema.description } : {} ),
+      ...( availability < 1 ? { availability } : {} ),
       planBias:        ctx.planBias,
       planId:          ctx.planId,
       stepId:          ctx.stepId,
@@ -357,6 +365,7 @@ export class AffordanceSynthesizer implements CognitiveEngine {
         available:       a.available,
         tags:            a.tags,
         description:     a.description,
+        ...( a.availability !== undefined ? { availability: a.availability } : {} ),
         planBias:        a.planBias,
         planId:          a.planId,
         stepId:          a.stepId,

--- a/src/cognition/agency/engines/reafference.engine.ts
+++ b/src/cognition/agency/engines/reafference.engine.ts
@@ -28,7 +28,7 @@ import type { CognitiveBus, CognitiveEvent } from '#cognition/bus'
 import type { CognitiveEngine, EngineResult } from '#cognition/types'
 import type { CognitiveEventSchema } from '#cognition/schema.registry'
 import type { SchemaRepertoire } from '#agency/schemas/repertoire'
-import { schemaEntityId } from '#agency/schemas/repertoire'
+import { schemaEntityId, availabilityEntityId } from '#agency/schemas/repertoire'
 import { AWAIT_TIMEOUT } from '#agency/engines/motor.schema.executor'
 
 const PROC_THRESHOLD = 0.60   // mirror of repertoire's threshold for the habitual-count metric
@@ -190,9 +190,27 @@ export class ReafferenceEngine implements CognitiveEngine {
     // ── 1. Fold each outcome into its skill ──────────────────────
     let updates    = 0
     let discovered = 0
+    let refused    = 0
     for( const { id, meta: m, fromState } of outcomes ){
       const schema = str( m['schema'] )
       if( !schema ){ if( fromState ) del.push( id ); continue }
+
+      // POLICY_REAFFERENCE P2 — a refusal is NOT a failure. Route it to the
+      // availability layer and stop: it must never touch LearnedSkill (value,
+      // habit, param priors), or the Will learns it is unskilled at something it
+      // is merely forbidden to do. The awaiting intent is still freed, and a
+      // refused plan step is signalled unsuccessful so the plan doesn't hang.
+      if( m['refused'] === true ){
+        const finality = str( m['finality'] ) === 'class' ? 'class' : 'instance'
+        this._repertoire.recordRefusal( schema, finality, tick )
+        if( fromState ) del.push( id )
+        const refusedIntent = str( m['intentId'] )
+        if( refusedIntent ) del.push( refusedIntent )
+        const refusedPlan = str( m['planId'] )
+        if( refusedPlan ) this._emitPlanOutcome( refusedPlan, str( m['stepId'] ), schema, false, 0, 0, tick )
+        refused++
+        continue
+      }
 
       const { skill, proceduralized } = this._repertoire.recordOutcome({
         schema,
@@ -235,19 +253,23 @@ export class ReafferenceEngine implements CognitiveEngine {
       }
     }
 
-    // ── 2. Forgetting curve over the competence layer ────────────
+    // ── 2. Forgetting curve over the competence layer + availability recovery ──
     const dropped = this._repertoire.decay( tick )
-    for( const id of dropped ){
+    for( const id of dropped.skills ){
       del.push(`agency-skill-${ id }`)
       del.push( schemaEntityId( id ) )   // composite mirror (harmless no-op for primitives)
     }
+    for( const id of dropped.availability )
+      del.push( availabilityEntityId( id ) )   // fully-recovered ⇒ remove the mirror
 
-    // ── 3. Mirror learned composite templates ────────────────────
+    // ── 3. Mirror learned composite templates + availability ─────
     // Skills become `agency.skill` (above); the invented composite *definitions*
     // must travel too, or a snapshot/restore brings back a skill whose schema is
     // gone and the executor can't expand it. Idempotent re-write each tick, like
     // GoalManager._persistGoals. Empty until a composite is actually learned.
-    for( const e of this._repertoire.compositeEntities() ) set.push( e )
+    for( const e of this._repertoire.compositeEntities() )   set.push( e )
+    // Availability entries (P2) mirror the same way — empty until a refusal lands.
+    for( const e of this._repertoire.availabilityEntities() ) set.push( e )
 
     // ── 4. Telemetry ─────────────────────────────────────────────
     const skills    = this._repertoire.skills()
@@ -259,6 +281,9 @@ export class ReafferenceEngine implements CognitiveEngine {
       [ 'agency.habitual.count',   habitual ],
       [ 'agency.sensory.confirmed', sensory ],
     )
+    // Only emit the refusal metric when it fired — a never-refused Will writes
+    // nothing here, preserving the byte-identical quiet path (cf. EXAFFERENCE P3).
+    if( refused > 0 ) metrics.push([ 'agency.refused.count', refused ])
 
     return { commands: { set, delete: del, metrics } }
   }

--- a/src/cognition/agency/reconcile.learning.ts
+++ b/src/cognition/agency/reconcile.learning.ts
@@ -24,6 +24,14 @@ export interface HostAckResult {
   /** −1..1 felt valence of the outcome. */
   valence?:       number
   description?:   string
+  /**
+   * POLICY_REAFFERENCE P2 — this ack is a policy REFUSAL, not a world failure.
+   * The ReafferenceEngine routes it to the availability layer (NOT competence):
+   * a refusal must never teach the Will it is unskilled at something it is merely
+   * forbidden to do. `finality` decides how hard availability is cut.
+   */
+  refused?:       boolean
+  finality?:      'class' | 'instance'
 }
 
 /**
@@ -71,6 +79,7 @@ export function reconcileInvocation(
       mode:             'external',
       tick,
       reconciled:       true,
+      ...( result.refused ? { refused: true, finality: result.finality ?? 'instance' } : {} ),
       ...( provenance.planId ? { planId: provenance.planId } : {} ),
       ...( provenance.stepId ? { stepId: provenance.stepId } : {} ),
     },

--- a/src/cognition/agency/schemas/repertoire.ts
+++ b/src/cognition/agency/schemas/repertoire.ts
@@ -39,6 +39,23 @@ const IDLE_TICKS        = 200   // ticks of disuse before forgetting starts
 const DECAY_RATE        = 0.02  // habit lost per decay application
 const DROP_HABIT        = 0.05  // below this (and learned) the skill is forgotten
 
+// ── availability layer (POLICY_REAFFERENCE P2) ────────────────
+// Availability is NOT competence. It answers "may I use this schema", learned
+// from policy refusals, and is kept strictly apart from LearnedSkill so a
+// refusal never teaches the Will it is *unskilled* at something it is merely
+// *forbidden* to do. A `class` refusal ("never, under this policy") drives
+// availability down hard; an `instance` refusal ("not with those parameters")
+// dents it lightly — the Will should keep reaching for the ability, just not
+// that way. Recovery is slow but real, so a policy change is re-discoverable:
+// availability never floors at zero, and it climbs back toward 1 with disuse of
+// the refusal. P2 keys availability by SCHEMA; per-(schema, params) envelope
+// narrowing is a follow-up that belongs at selection time, not fielding time.
+const AVAIL_DROP_CLASS    = 0.50  // multiplicative cut on a class-final refusal
+const AVAIL_DROP_INSTANCE = 0.12  // lighter cut on an instance-final refusal
+const AVAIL_FLOOR         = 0.05  // never zero — re-probe must always be possible
+const AVAIL_RECOVERY      = 0.02  // per-decay climb back toward 1
+const AVAIL_RECOVERED     = 0.999 // at/above this the entry is dropped (quiet path)
+
 export interface OutcomeObservation {
   schema:         string
   success:        boolean
@@ -54,6 +71,9 @@ export class SchemaRepertoire {
   private _skills    = new Map<string, LearnedSkill>()
   /** Tracks which templates were learned at runtime (vs innate) so decay can forget them. */
   private _learned   = new Set<string>()
+  /** Availability layer (P2): schema → { value 0..1, lastRefusedTick }. Empty until
+   *  a refusal lands — a never-refused Will writes nothing here (byte-identical). */
+  private _availability = new Map<string, { value: number; lastRefusedTick: number }>()
 
   constructor( seed: MotorSchema[] = INNATE_SCHEMAS ){
     for( const s of seed ) this._templates.set( s.id, s )
@@ -84,6 +104,32 @@ export class SchemaRepertoire {
   // ── skills ────────────────────────────────────────────────────
   skills(): ReadonlyMap<string, LearnedSkill> { return this._skills }
   getSkill( id: string ): LearnedSkill | undefined { return this._skills.get( id ) }
+
+  // ── availability (P2) ─────────────────────────────────────────
+  availability(): ReadonlyMap<string, { value: number; lastRefusedTick: number }> { return this._availability }
+
+  /**
+   * How available a schema is right now, 0..1. Absent from the ledger ⇒ 1
+   * (fully available — the common case). This is the ONLY value the
+   * AffordanceSynthesizer reads; it never touches competence.
+   */
+  availabilityOf( schema: string ): number {
+    return this._availability.get( schema )?.value ?? 1
+  }
+
+  /**
+   * Fold a policy refusal into the availability layer (NOT competence). A
+   * `class` refusal cuts availability hard; an `instance` refusal dents it
+   * lightly. Multiplicative so repeated refusals compound toward — but never
+   * reach — zero, keeping re-probe alive.
+   */
+  recordRefusal( schema: string, finality: 'class' | 'instance', tick: number ): number {
+    const prev = this._availability.get( schema )?.value ?? 1
+    const drop = finality === 'class' ? AVAIL_DROP_CLASS : AVAIL_DROP_INSTANCE
+    const value = Math.max( AVAIL_FLOOR, prev * ( 1 - drop ) )
+    this._availability.set( schema, { value, lastRefusedTick: tick } )
+    return value
+  }
 
   /**
    * Fold one outcome into the schema's learned skill. Returns the updated skill
@@ -118,12 +164,14 @@ export class SchemaRepertoire {
   }
 
   /**
-   * Forgetting curve over the competence layer. Skills unused for IDLE_TICKS
-   * lose habit; learned composites that fall below DROP_HABIT are dropped
-   * entirely (template + skill). Returns the schema ids that were forgotten.
+   * Forgetting curve over the competence layer, plus availability recovery.
+   * Skills unused for IDLE_TICKS lose habit; learned composites below DROP_HABIT
+   * are dropped entirely (template + skill). Availability entries climb back
+   * toward 1 and are dropped once fully recovered. Returns the ids that were
+   * removed from each layer so their mirrored state entities can be deleted.
    */
-  decay( tick: number ): string[] {
-    const dropped: string[] = []
+  decay( tick: number ): { skills: string[]; availability: string[] } {
+    const skills: string[] = []
     for( const [ id, skill ] of this._skills ){
       if( tick - skill.lastEnactedTick <= IDLE_TICKS ) continue
 
@@ -132,12 +180,23 @@ export class SchemaRepertoire {
         this._skills.delete( id )
         this._templates.delete( id )
         this._learned.delete( id )
-        dropped.push( id )
+        skills.push( id )
         continue
       }
       this._skills.set( id, { ...skill, habitStrength } )
     }
-    return dropped
+
+    // Availability recovery (P2): each entry climbs slowly back toward 1, so a
+    // policy change is re-discoverable. A fully-recovered entry is dropped, so a
+    // Will that was refused long ago returns to the byte-identical quiet path.
+    const availability: string[] = []
+    for( const [ id, avail ] of this._availability ){
+      const value = avail.value + AVAIL_RECOVERY * ( 1 - avail.value )
+      if( value >= AVAIL_RECOVERED ){ this._availability.delete( id ); availability.push( id ) }
+      else this._availability.set( id, { ...avail, value } )
+    }
+
+    return { skills, availability }
   }
 
   // ── PMA portability (Phase 6 reads these) ─────────────────────
@@ -188,6 +247,30 @@ export class SchemaRepertoire {
       this._learned.add( s.id )
     }
   }
+
+  /** Availability ledger encoded as `agency.availability` state entities (P2).
+   *  Empty until a refusal lands, so the quiet path writes nothing. */
+  availabilityEntities(): EntityInput[] {
+    const out: EntityInput[] = []
+    for( const [ schema, a ] of this._availability )
+      out.push( availabilityEntity( schema, a.value, a.lastRefusedTick ) )
+    return out
+  }
+
+  /** Rehydrate the availability ledger from state after a restore. Idempotent;
+   *  keeps whichever value is more restrictive so a concurrent refusal isn't lost. */
+  restoreAvailability( entities: ReadonlySimulationState['entities'] ): void {
+    for( const e of entities.values() ){
+      if( e.type !== AVAILABILITY_ENTITY_TYPE ) continue
+      const m = ( e.metadata ?? {} ) as Record<string, unknown>
+      const schema = typeof m['schema'] === 'string' ? m['schema'] : ''
+      if( !schema ) continue
+      const value = typeof m['value'] === 'number' ? m['value'] : 1
+      const tick  = typeof m['lastRefusedTick'] === 'number' ? m['lastRefusedTick'] : 0
+      const prev  = this._availability.get( schema )
+      if( !prev || value < prev.value ) this._availability.set( schema, { value, lastRefusedTick: tick } )
+    }
+  }
 }
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
@@ -207,6 +290,23 @@ function freshSkill( schema: string, value: number, tick: number ): LearnedSkill
 
 function clamp01( n: number ): number {
   return n < 0 ? 0 : n > 1 ? 1 : n
+}
+
+// ─── availability ⇄ state-entity codec (P2) ──────────────────────────────────
+
+/** State-entity type for a mirrored availability entry. */
+export const AVAILABILITY_ENTITY_TYPE = 'agency.availability'
+
+/** Stable entity id for a schema's availability mirror (idempotent re-writes). */
+export function availabilityEntityId( schema: string ): string { return `agency-availability-${ schema }` }
+
+/** Encode one availability entry as a state entity. */
+function availabilityEntity( schema: string, value: number, lastRefusedTick: number ): EntityInput {
+  return {
+    id:   availabilityEntityId( schema ),
+    type: AVAILABILITY_ENTITY_TYPE,
+    metadata: { schema, value, lastRefusedTick },
+  }
 }
 
 // ─── composite ⇄ state-entity codec (snapshot/replay) ────────────────────────

--- a/src/cognition/agency/selection.scoring.ts
+++ b/src/cognition/agency/selection.scoring.ts
@@ -147,7 +147,7 @@ export function scoreAffordance(
   bias: BiasContext,
   w:    ScoreWeights = DEFAULT_WEIGHTS,
 ): number {
-  return (
+  const raw = (
       w.goal    * goalRelevance( a, bias )
     + w.reward  * a.expectedReward
     + w.novelty * novelty( a )
@@ -158,6 +158,12 @@ export function scoreAffordance(
     - w.inhib   * bias.inhibition
     - w.risk    * risk( a, bias )
   )
+  // POLICY_REAFFERENCE P2 — policy availability damps a POSITIVE activation only,
+  // never flipping its sign: a refused ability competes weakly (so it is rarely
+  // chosen) yet is never removed from the field, keeping re-probe alive as
+  // availability recovers. Absent ⇒ 1 ⇒ no change (byte-identical quiet path).
+  const availability = a.availability ?? 1
+  return raw > 0 ? raw * availability : raw
 }
 
 /**

--- a/src/cognition/agency/types.ts
+++ b/src/cognition/agency/types.ts
@@ -140,6 +140,15 @@ export interface Affordance {
    * competition WITHOUT bypassing it (the plan biases; the field still decides).
    */
   planBias?:       number
+  /**
+   * Policy availability 0..1 (POLICY_REAFFERENCE P2) — learned from refusals,
+   * distinct from `available` (precondition satisfaction) and from competence.
+   * Present only when < 1 (a refusal has dented it); absent ⇒ fully available,
+   * so a never-refused Will's field is byte-identical. Damps positive activation
+   * in the competition without flipping its sign, so a suppressed ability still
+   * gets an occasional re-probe and can climb back as availability recovers.
+   */
+  availability?:   number
   /** Provenance: the plan whose frontier step projected this affordance. */
   planId?:         string
   /** Provenance: the frontier step id — flows through to action.outcome so the plan advances. */

--- a/src/stem/tracts/effector.controller.ts
+++ b/src/stem/tracts/effector.controller.ts
@@ -210,6 +210,8 @@ export class effectorController {
     for( const refusal of queue )
       this.confirmExecution( instance, refusal.intentId, {
         success:     false,
+        refused:     true,
+        finality:    refusal.finality === 'class' ? 'class' : 'instance',
         description: `refused by policy: ${refusal.reasonCode} (${refusal.finality})`,
       } )
   }
@@ -259,6 +261,10 @@ export class effectorController {
       success:     boolean
       description: string
       metrics?:    Record<string, number>
+      /** POLICY_REAFFERENCE P2 — set when the ack is a policy refusal, so the
+       *  ReafferenceEngine routes it to availability rather than competence. */
+      refused?:    boolean
+      finality?:   'class' | 'instance'
     },
   ): void {
     const tick = instance.tickCount

--- a/tests/unit/agency.learning.test.ts
+++ b/tests/unit/agency.learning.test.ts
@@ -119,7 +119,7 @@ describe('SchemaRepertoire — learning rules', () => {
     rep.recordOutcome({ schema: 'macro', success: true, outcomeQuality: 0.5, predictedReward: 0.5, tick: 1 })
 
     let dropped: string[] = []
-    for( let t = 1000; t < 1012; t++ ) dropped = dropped.concat( rep.decay( t ) )
+    for( let t = 1000; t < 1012; t++ ) dropped = dropped.concat( rep.decay( t ).skills )
 
     expect( dropped ).toContain('macro')
     expect( rep.getSchema('macro') ).toBeUndefined()   // template forgotten too

--- a/tests/unit/policy.availability.test.ts
+++ b/tests/unit/policy.availability.test.ts
@@ -1,0 +1,179 @@
+// ─────────────────────────────────────────────────────────────
+// tests/unit/policy.availability.test.ts
+// ─────────────────────────────────────────────────────────────
+// POLICY_REAFFERENCE P2 — refusal teaches availability, not competence.
+// Proves the availability layer in the repertoire (class cuts hard, instance
+// dents lightly, floors above zero, recovers with disuse, mirrors + restores),
+// that the ReafferenceEngine routes a `refused` outcome to availability while
+// leaving LearnedSkill untouched — and that a real failure still moves
+// competence normally — and that availability damps competitive activation
+// without ever removing the affordance from the field (re-probe survives).
+
+import { describe, it, expect } from 'vitest'
+import type {
+  ReadonlySimulationState, SimulationContext, StateCommands, SimulationEntity,
+} from '#core/types'
+import { SchemaRepertoire, AVAILABILITY_ENTITY_TYPE, availabilityEntityId } from '#agency/schemas/repertoire'
+import { ReafferenceEngine } from '#agency/engines/reafference.engine'
+import { scoreAffordance, DEFAULT_WEIGHTS } from '#agency/selection.scoring'
+import type { Affordance } from '#agency/types'
+
+const CTX = {} as unknown as SimulationContext
+
+interface MutState { tick: number; time: number; entities: Map<string, SimulationEntity>; metrics: Map<string, number> }
+const freshState = (): MutState => ({ tick: 0, time: 0, entities: new Map(), metrics: new Map() })
+const frozen = ( s: MutState ): ReadonlySimulationState => s as unknown as ReadonlySimulationState
+function apply( s: MutState, c: StateCommands | undefined ): void {
+  if( !c ) return
+  for( const e of c.set ?? [] ) s.entities.set( e.id, { createdAt: 0, updatedAt: 0, ...e } as SimulationEntity )
+  for( const id of c.delete ?? [] ) s.entities.delete( id )
+  for( const [ k, v ] of c.metrics ?? [] ) s.metrics.set( k, v )
+}
+
+function outcome( s: MutState, id: string, meta: Record<string, unknown> ): void {
+  s.entities.set( id, { id, type: 'agency.outcome', createdAt: 0, updatedAt: 0, metadata: meta } as SimulationEntity )
+}
+
+// ── the availability layer (repertoire) ───────────────────────────────────────
+
+describe('P2 — availability layer', () => {
+  it('is fully available (1) for a schema that was never refused', () => {
+    const rep = new SchemaRepertoire()
+    expect( rep.availabilityOf('trade') ).toBe( 1 )
+    expect( rep.availability().size ).toBe( 0 )       // quiet path writes nothing
+  })
+
+  it('cuts availability HARD on a class refusal, LIGHTLY on an instance refusal', () => {
+    const rep = new SchemaRepertoire()
+    rep.recordRefusal('trade', 'class', 1 )
+    rep.recordRefusal('move',  'instance', 1 )
+    expect( rep.availabilityOf('trade') ).toBeLessThan( rep.availabilityOf('move') )
+    expect( rep.availabilityOf('move') ).toBeGreaterThan( 0.8 )   // barely dented
+  })
+
+  it('compounds repeated refusals toward — but never to — zero', () => {
+    const rep = new SchemaRepertoire()
+    for( let i = 0; i < 20; i++ ) rep.recordRefusal('trade', 'class', i )
+    const v = rep.availabilityOf('trade')
+    expect( v ).toBeGreaterThan( 0 )         // re-probe always possible
+    expect( v ).toBeLessThan( 0.1 )
+  })
+
+  it('recovers slowly with disuse and drops the entry once fully recovered', () => {
+    const rep = new SchemaRepertoire()
+    rep.recordRefusal('trade', 'class', 1 )
+    const dented = rep.availabilityOf('trade')
+
+    let climbed = dented
+    for( let t = 2; t < 400; t++ ){
+      const dropped = rep.decay( t )
+      const now = rep.availabilityOf('trade')
+      expect( now ).toBeGreaterThanOrEqual( climbed )   // monotone recovery
+      climbed = now
+      if( dropped.availability.includes('trade') ) break
+    }
+    expect( rep.availabilityOf('trade') ).toBe( 1 )     // fully recovered ⇒ absent ⇒ 1
+    expect( rep.availability().size ).toBe( 0 )
+  })
+
+  it('mirrors to state entities and restores from them', () => {
+    const rep = new SchemaRepertoire()
+    rep.recordRefusal('trade', 'class', 5 )
+    const entities = rep.availabilityEntities()
+    expect( entities ).toHaveLength( 1 )
+    expect( entities[0]!.id ).toBe( availabilityEntityId('trade') )
+    expect( entities[0]!.type ).toBe( AVAILABILITY_ENTITY_TYPE )
+
+    const restored = new SchemaRepertoire()
+    const map = new Map( entities.map( e => [ e.id, { ...e, createdAt: 0, updatedAt: 0 } as SimulationEntity ] ) )
+    restored.restoreAvailability( map as ReadonlySimulationState['entities'] )
+    expect( restored.availabilityOf('trade') ).toBeCloseTo( rep.availabilityOf('trade'), 10 )
+  })
+})
+
+// ── the reafference routing ───────────────────────────────────────────────────
+
+describe('P2 — refusal routes to availability, not competence', () => {
+  it('a refused outcome dents availability and leaves LearnedSkill untouched', async () => {
+    const rep = new SchemaRepertoire()
+    const reaff = new ReafferenceEngine( rep )
+    const s = freshState()
+    outcome( s, 'o-1', { schema: 'trade', intentId: 'i-1', success: false, refused: true, finality: 'class' } )
+
+    const r = await reaff.react( 0, 4, frozen( s ), CTX )
+    apply( s, r.commands )
+
+    expect( rep.availabilityOf('trade') ).toBeLessThan( 1 )   // availability moved
+    expect( rep.getSkill('trade') ).toBeUndefined()           // competence untouched — no skill created
+    expect( s.entities.has('i-1') ).toBe( false )             // awaiting intent still freed
+    expect( s.entities.has('o-1') ).toBe( false )             // outcome consumed
+  })
+
+  it('a genuine failure (not refused) still moves competence normally', async () => {
+    const rep = new SchemaRepertoire()
+    const reaff = new ReafferenceEngine( rep )
+    const s = freshState()
+    outcome( s, 'o-1', { schema: 'trade', intentId: 'i-1', success: false, outcomeQuality: 0.1, predictedReward: 0.5 } )
+
+    const r = await reaff.react( 0, 4, frozen( s ), CTX )
+    apply( s, r.commands )
+
+    expect( rep.getSkill('trade') ).toBeDefined()             // competence recorded
+    expect( rep.getSkill('trade')!.enactments ).toBe( 1 )
+    expect( rep.availabilityOf('trade') ).toBe( 1 )           // availability untouched
+  })
+
+  it('emits the refusal metric only when a refusal fired (quiet path stays silent)', async () => {
+    const rep = new SchemaRepertoire()
+    const reaff = new ReafferenceEngine( rep )
+    const s = freshState()
+
+    const quiet = await reaff.react( 0, 1, frozen( s ), CTX )
+    expect( ( quiet.commands?.metrics ?? [] ).find( m => m[0] === 'agency.refused.count') ).toBeUndefined()
+
+    outcome( s, 'o-1', { schema: 'trade', intentId: 'i-1', success: false, refused: true, finality: 'instance' } )
+    const loud = await reaff.react( 0, 2, frozen( s ), CTX )
+    expect( ( loud.commands?.metrics ?? [] ).find( m => m[0] === 'agency.refused.count')?.[1] ).toBe( 1 )
+  })
+})
+
+// ── the competition damping ───────────────────────────────────────────────────
+
+function affordance( over: Partial<Affordance> = {} ): Affordance {
+  return {
+    id: 'a-1', schema: 'trade', source: 'external', parameters: {},
+    expectedValence: 0, expectedReward: 0.8, cost: 0.1, habitStrength: 0,
+    available: true, tags: [], tick: 1, ...over,
+  }
+}
+const bias = {
+  goalTargets:     new Set<string>(),
+  maxGoalPriority: 0,
+  drives:          { energy: 0, sleep: 0, stress: 0, social: 0 },
+  threat:          0,
+  inhibition:      0,
+}
+
+describe('P2 — availability damps activation, never removes the field entry', () => {
+  it('a low-availability affordance scores strictly below its available twin', () => {
+    const open      = scoreAffordance( affordance(), bias, DEFAULT_WEIGHTS )
+    const suppressed = scoreAffordance( affordance({ availability: 0.1 }), bias, DEFAULT_WEIGHTS )
+    expect( open ).toBeGreaterThan( 0 )
+    expect( suppressed ).toBeLessThan( open )
+    expect( suppressed ).toBeGreaterThan( 0 )   // still positive ⇒ still winnable ⇒ re-probe survives
+  })
+
+  it('is byte-identical when availability is absent (the quiet path)', () => {
+    const withField = scoreAffordance( affordance({ availability: 1 }), bias, DEFAULT_WEIGHTS )
+    const noField   = scoreAffordance( affordance(), bias, DEFAULT_WEIGHTS )
+    expect( withField ).toBe( noField )
+  })
+
+  it('recovered availability restores full competitive weight', () => {
+    const base = scoreAffordance( affordance(), bias, DEFAULT_WEIGHTS )
+    const dented = scoreAffordance( affordance({ availability: 0.3 }), bias, DEFAULT_WEIGHTS )
+    const recovered = scoreAffordance( affordance({ availability: 0.99 }), bias, DEFAULT_WEIGHTS )
+    expect( dented ).toBeLessThan( recovered )
+    expect( recovered ).toBeCloseTo( base, 1 )
+  })
+})


### PR DESCRIPTION
The learning half of `.TODO/POLICY_REAFFERENCE.md`, on top of the P0+P1 seam (#72). A policy denial no longer reconciles as a plain failure — it is routed to a new **availability layer**, kept strictly apart from competence, so **a refusal never teaches the Will it is unskilled at something it is merely forbidden to do.** The Will learns the shape of its own permissions and stops re-probing the wall; a policy change stays re-discoverable.

## The load-bearing distinction

| | teaches | signal |
| :--- | :--- | :--- |
| Failure | "I am not skilled at this" | competence ↓, re-probe rational |
| Refusal | "this is not available to me" | availability ↓, re-probe wasteful |

Folding a denial into `LearnedSkill` would corrupt value/habit/param-priors with a signal that has nothing to do with execution quality. P2 keeps them apart.

## Changes

- **`reconcile.learning.ts`** — refused outcomes carry a discriminated `{ refused, finality }` marker (not a magic `outcomeQuality`).
- **`repertoire.ts`** — the availability layer, parallel to but separate from skills: `recordRefusal` (class cuts 0.50, instance 0.12, floored at 0.05 so re-probe always survives), recovery folded into `decay()` (climbs back, entry dropped at full recovery → quiet path byte-identical), mirrored to `agency.availability` state entities with restore.
- **`reafference.engine.ts`** — a `refused` outcome calls `recordRefusal` and **stops**: no `recordOutcome`, no discovery, no proceduralization; the awaiting intent is still freed.
- **`selection.scoring.ts`** — availability damps a **positive** activation, never flips a negative one: a refused ability competes weakly but is never removed from the field, so **re-probe survives** and recovers.
- **`affordance.synthesizer.ts` / `types.ts`** — `Affordance.availability` set only when `< 1` (omitted otherwise → field byte-identical for a never-refused Will).

## Scope

P2 keys availability by **schema**. Per-`(schema, params)` envelope narrowing bites at selection time, not fielding time (the Will hasn't bound params when the field is built) — a deferred follow-up. Class-vs-instance is honoured here via cut magnitude.

## Verification

- Typecheck clean.
- New tests: `tests/unit/policy.availability.test.ts` (11).
- Full suite **1139 passed / 2 skipped across 171 files**, including `replay.equivalence` — byte-identical holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)