### PR TITLE
feat(policy): P3 — refusal as rupture

### DIFF
--- a/.TODO/POLICY_REAFFERENCE.md
+++ b/.TODO/POLICY_REAFFERENCE.md
@@ -314,15 +314,29 @@ shape of its own permissions* rather than re-probing the wall (P1+P2). What
 remains is refinement, not foundation: P3 (refusal as rupture), P4 (escalate as
 speech act), P5 (HELM adapter), and the deferred per-params envelope narrowing.
 
-### P3 — Refusal as rupture (reuse P4 machinery)
-- [ ] Map `severity` → rupture. At/above `RUPTURE_REVOKE_GATE` (0.7) write the
-      existing `agency.revocation` tombstone: the Will **lets go** of a
-      commitment it was still deliberating, no successor committed.
-- [ ] Provenance: a refusal is self-caused (carries `intentId`) ⇒ **reafferent by
-      construction**. Assert it can never be counted as exafferent salience —
-      the mind must not be able to rupture itself with its own boundary.
-- [ ] Tests: high-severity refusal revokes a `deliberating` intent T+1;
-      low-severity does not; refusal contributes zero exafferent rupture.
+### P3 — Refusal as rupture (reuse P4 machinery) ⟶ done (2026-07-21)
+- [x] **`finality` IS the severity signal** (no separate numeric field — keeps the
+      vocabulary identical to the HELM proposal). A `class` refusal of the schema
+      the Will is currently `deliberating` writes the existing `agency.revocation`
+      tombstone (`ActionSelector`, extended P4 block): the Will lets go, no
+      successor committed. An `instance` refusal ("not with those params") never
+      revokes — a still-deliberating attempt may yet succeed.
+- [x] **The invariant, by construction.** A refusal is an `agency.outcome`, never a
+      `percept`; `computeRupture` reads only `provenance:'exafferent'` percepts, so
+      a refusal contributes ZERO exafferent rupture — the mind cannot rupture
+      itself with its own boundary. Policy revocation is a SEPARATE, explicit
+      trigger (`refusedClassSchemas`) with its own reason code `'policy-refusal'`
+      (vs `'exafferent-rupture'`) and its own metric `agency.policy.revoked`; the
+      exafferent scalar, switch-cost softening, and `situation.stability` are all
+      untouched. Quiet path (no refusal) is byte-identical — the scan runs only
+      when an intent is deliberating and writes nothing when the set is empty.
+- [x] Tests (`tests/unit/policy.rupture.test.ts`, 5): a class refusal of the
+      deliberating schema tombstones it + emits `agency.policy.revoked` + labels
+      the event `policy-refusal`; an instance refusal does not; a class refusal of
+      a *different* schema does not; a refused outcome erodes no stability and
+      fires no rupture event (zero exafferent contribution); the exafferent path
+      still revokes, labelled distinctly. Full suite **1144 passed / 2 skipped
+      (172 files)**, replay-equivalence green. Typecheck clean.
 
 ### P4 — ESCALATE is a speech act
 - [ ] ProactiveCommunicator voices the ask in first person, carrying the

--- a/src/cognition/agency/engines/action.selector.ts
+++ b/src/cognition/agency/engines/action.selector.ts
@@ -294,19 +294,26 @@ export class ActionSelector implements CognitiveEngine {
       }
     })
 
-    // ── Commitment revocation (EXAFFERENCE P4) ───────────────────
-    // A hard rupture doesn't just soften the switch cost — it lets go of a
-    // commitment still being weighed. We can't delete the `deliberating` intent
-    // here (Deliberation runs after us and would resurrect it set-after-delete),
-    // so we drop a tombstone the Deliberation engine + Executor honor next tick.
-    // No successor is committed — the field re-forms and the next tick selects.
-    if( deliberating && rupture >= RUPTURE_REVOKE_GATE ){
+    // ── Commitment revocation (EXAFFERENCE P4 · POLICY_REAFFERENCE P3) ──
+    // A commitment still being weighed is let go for either of two DISTINCT
+    // reasons: a hard exafferent rupture (the world surprised us), or a class
+    // policy refusal of the very schema we're deliberating (the boundary just
+    // declared it forbidden — deliberating our way into it is wasted). The two
+    // never mix: the refusal is an outcome, not a percept, so it contributes
+    // ZERO to the exafferent scalar. Either way we can't delete the
+    // `deliberating` intent here (Deliberation runs after us and would resurrect
+    // it set-after-delete), so we drop a tombstone the Deliberation engine +
+    // Executor honor next tick. No successor is committed — the field re-forms.
+    const policyRevoke = !!deliberating && refusedClassSchemas( state ).has( deliberating.schema )
+    if( deliberating && ( rupture >= RUPTURE_REVOKE_GATE || policyRevoke ) ){
+      const reason     = policyRevoke ? 'policy-refusal' : 'exafferent-rupture'
+      const revRupture = policyRevoke ? Math.max( rupture, RUPTURE_REVOKE_GATE ) : rupture
       if( this._bus ){
         try {
           this._bus.publish({
             type: 'agency.commitment.revoked', version: 1, sourceEngine: this.name,
             salience: 0.85,
-            payload: { from: deliberating.schema, reason: 'exafferent-rupture', rupture, tick },
+            payload: { from: deliberating.schema, reason, rupture: revRupture, tick },
           })
         }
         catch( err ){ logger.warn(`[selector] revoked publish failed: ${ err instanceof Error ? err.message : String( err ) }`) }
@@ -314,11 +321,12 @@ export class ActionSelector implements CognitiveEngine {
       this._lastRevoked = { schema: deliberating.schema, tick }   // Channel-B: flavor the next deliberation
       return {
         commands: {
-          set: [ revocationEntity( deliberating.id, deliberating.schema, rupture, tick ) ],
+          set: [ revocationEntity( deliberating.id, deliberating.schema, revRupture, tick ) ],
           metrics: [
             [ 'agency.field.eligible', eligible.length ],
             [ 'agency.selection.busy', 1 ],
             [ 'agency.commitment.revoked', 1 ],
+            ...( policyRevoke ? [ [ 'agency.policy.revoked', 1 ] as [ string, number ] ] : [] ),
             ...stabMetrics,
           ],
         },
@@ -630,6 +638,30 @@ function computeRupture(
 
   if( maxSalience <= RUPTURE_SALIENCE_GATE ) return 0
   return clamp01( ( maxSalience - RUPTURE_SALIENCE_GATE ) / ( 1 - RUPTURE_SALIENCE_GATE ) )
+}
+
+/**
+ * POLICY_REAFFERENCE P3 — schemas hit by a CLASS-final policy refusal visible in
+ * frozen state this tick (a refused `agency.outcome` lives exactly one tick).
+ *
+ * A refusal is an `agency.outcome`, never a `percept`, so it can NEVER feed
+ * computeRupture: the mind cannot rupture itself with its own boundary. This is
+ * a SEPARATE, explicit trigger — "the boundary just declared this forbidden, let
+ * go of any commitment I'm still weighing toward it" — distinct from a
+ * world-surprise exafferent rupture, and it carries its own revocation reason.
+ * Only `class` finality qualifies: an `instance` refusal means "not with those
+ * parameters", not "never", so a still-deliberating attempt may yet succeed.
+ */
+function refusedClassSchemas( state: ReadonlySimulationState ): Set<string> {
+  const out = new Set<string>()
+  for( const e of state.entities.values() ){
+    if( e.type !== 'agency.outcome') continue
+    const m = e.metadata
+    if( m?.['refused'] !== true || str( m?.['finality'] ) !== 'class') continue
+    const schema = str( m?.['schema'] )
+    if( schema ) out.add( schema )
+  }
+  return out
 }
 
 /**

--- a/tests/unit/policy.rupture.test.ts
+++ b/tests/unit/policy.rupture.test.ts
@@ -1,0 +1,102 @@
+// ─────────────────────────────────────────────────────────────
+// tests/unit/policy.rupture.test.ts
+// ─────────────────────────────────────────────────────────────
+// POLICY_REAFFERENCE P3 — refusal as rupture. A CLASS-final policy refusal of a
+// schema the Will is still deliberating makes it LET GO of that commitment,
+// reusing the EXAFFERENCE P4 tombstone. The load-bearing invariant: a refusal is
+// an agency.outcome, never a percept, so it contributes ZERO exafferent rupture —
+// the mind can never rupture itself with its own boundary. An instance refusal,
+// or a refusal of a different schema, never revokes.
+
+import { describe, it, expect } from 'vitest'
+import type { ReadonlySimulationState, SimulationContext } from '#core/types'
+import { ActionSelector } from '#agency/engines/action.selector'
+import { REVOCATION_TYPE, revocationId } from '#agency/revocation'
+
+const CTX = {} as unknown as SimulationContext
+
+interface Ent { id: string; type: string; metadata?: Record<string, unknown> }
+
+function makeState( tick: number, entities: Ent[], metrics: Record<string, number> = {} ): ReadonlySimulationState {
+  const em = new Map<string, unknown>()
+  for( const e of entities ) em.set( e.id, { id: e.id, type: e.type, createdAt: 0, updatedAt: 0, metadata: e.metadata } )
+  return { tick, time: 0, entities: em, metrics: new Map( Object.entries( metrics ) ) } as unknown as ReadonlySimulationState
+}
+
+const deliberating = ( id: string, schema: string ): Ent =>
+  ({ id, type: 'agency.intent', metadata: { status: 'deliberating', schema, candidates: [ { schema } ] } })
+
+/** A refused agency.outcome as applyPolicyOutcomes → reconcileInvocation writes it. */
+const refused = ( id: string, schema: string, finality: 'class' | 'instance' ): Ent =>
+  ({ id, type: 'agency.outcome', metadata: { schema, intentId: `i-${ schema }`, success: false, refused: true, finality } })
+
+/** A strong exafferent percept — the world-surprise path, for contrast. */
+const exafferent = ( id: string, salience: number, tick: number ): Ent =>
+  ({ id, type: 'percept', metadata: { salience, provenance: 'exafferent', tick, entityId: 'w', category: 'message' } })
+
+function busSpy(): { bus: unknown; events: Array<{ type: string; payload: Record<string, unknown> }> } {
+  const events: Array<{ type: string; payload: Record<string, unknown> }> = []
+  return { bus: { publish: ( e: { type: string; payload: Record<string, unknown> } ) => events.push( e ) }, events }
+}
+
+const setOf     = ( r: { commands?: { set?: Array<{ id: string; type: string }> } } ) => r.commands?.set ?? []
+const metricVal = ( r: { commands?: { metrics?: Array<[ string, number ]> } }, k: string ) =>
+  ( r.commands?.metrics ?? [] ).find( m => m[0] === k )?.[1]
+
+async function run( state: ReadonlySimulationState ) {
+  const sel = new ActionSelector()
+  const spy = busSpy(); sel.attachBus( spy.bus as never )
+  const res = await sel.react( 0, ( state as { tick: number } ).tick, state, CTX )
+  return { res, events: spy.events }
+}
+
+describe('P3 — a class refusal revokes an in-flight deliberation of the same schema', () => {
+  it('writes a tombstone for the deliberating intent + emits agency.policy.revoked', async () => {
+    const s = makeState( 5, [ deliberating('intent-d', 'trade'), refused('o', 'trade', 'class') ] )
+    const { res, events } = await run( s )
+
+    const tomb = setOf( res ).find( e => e.type === REVOCATION_TYPE )
+    expect( tomb ).toBeDefined()
+    expect( tomb!.id ).toBe( revocationId('intent-d') )
+    expect( metricVal( res, 'agency.commitment.revoked') ).toBe( 1 )
+    expect( metricVal( res, 'agency.policy.revoked') ).toBe( 1 )
+
+    const ev = events.find( e => e.type === 'agency.commitment.revoked')
+    expect( ev!.payload['reason'] ).toBe('policy-refusal')   // NOT exafferent-rupture
+  })
+
+  it('an INSTANCE refusal does not revoke (not with those params ≠ never)', async () => {
+    const s = makeState( 5, [ deliberating('intent-d', 'trade'), refused('o', 'trade', 'instance') ] )
+    const { res, events } = await run( s )
+    expect( setOf( res ).some( e => e.type === REVOCATION_TYPE ) ).toBe( false )
+    expect( metricVal( res, 'agency.policy.revoked') ).toBeUndefined()
+    expect( events.some( e => e.type === 'agency.commitment.revoked') ).toBe( false )
+  })
+
+  it('a class refusal of a DIFFERENT schema leaves the deliberation alone', async () => {
+    const s = makeState( 5, [ deliberating('intent-d', 'ponder'), refused('o', 'trade', 'class') ] )
+    const { res } = await run( s )
+    expect( setOf( res ).some( e => e.type === REVOCATION_TYPE ) ).toBe( false )
+    expect( metricVal( res, 'agency.policy.revoked') ).toBeUndefined()
+  })
+})
+
+describe('P3 — the invariant: a refusal never feeds exafferent rupture', () => {
+  it('a refused outcome contributes zero rupture (no stability erosion, no rupture event)', async () => {
+    // Deliberating a DIFFERENT schema, so policy-revoke cannot fire either — the
+    // only thing present that could rupture is the refusal, and it must not.
+    const s = makeState( 5, [ deliberating('intent-d', 'ponder'), refused('o', 'trade', 'class') ] )
+    const { res, events } = await run( s )
+    expect( metricVal( res, 'situation.stability') ).toBeUndefined()          // no erosion
+    expect( events.some( e => e.type === 'agency.situation.rupture') ).toBe( false )
+    expect( setOf( res ).some( e => e.type === REVOCATION_TYPE ) ).toBe( false )
+  })
+
+  it('the exafferent path still revokes and is labelled distinctly', async () => {
+    const s = makeState( 5, [ deliberating('intent-d', 'ponder'), exafferent('p', 0.95, 5 ) ] )
+    const { res, events } = await run( s )
+    expect( setOf( res ).some( e => e.type === REVOCATION_TYPE ) ).toBe( true )
+    expect( metricVal( res, 'agency.policy.revoked') ).toBeUndefined()        // not policy-driven
+    expect( events.find( e => e.type === 'agency.commitment.revoked')!.payload['reason'] ).toBe('exafferent-rupture')
+  })
+})


### PR DESCRIPTION
On top of P0–P2 (#72, #73). A **class**-final policy refusal of the schema the Will is currently *deliberating* makes it **let go** of that commitment — reusing the EXAFFERENCE P4 `agency.revocation` tombstone. Deliberating one's way into a just-forbidden action is wasted; the `ActionSelector` drops the tombstone, the Deliberation engine + Executor honor it next tick, no successor committed.

## The load-bearing invariant

A refusal is an `agency.outcome`, never a `percept`, and `computeRupture` reads only `provenance:'exafferent'` percepts — so **a refusal contributes zero exafferent rupture. The mind cannot rupture itself with its own boundary.**

Policy revocation is a **separate, explicit** trigger (`refusedClassSchemas`), carrying its own reason code `'policy-refusal'` (vs `'exafferent-rupture'`) and metric `agency.policy.revoked`. The exafferent scalar, switch-cost softening, and `situation.stability` are all untouched.

## Details

- `finality` **is** the severity signal — no separate numeric field, keeping the vocabulary identical to the HELM proposal. `class` → "never" → revoke; `instance` → "not with those params" → a still-deliberating attempt may yet succeed, so no revocation.
- Quiet path byte-identical: the refusal scan runs only when an intent is deliberating and writes nothing when the set is empty.

## Verification

- Typecheck clean.
- New tests: `tests/unit/policy.rupture.test.ts` (5) — class-refusal revokes + labels `policy-refusal`; instance does not; different-schema does not; a refused outcome erodes no stability and fires no rupture event (zero exafferent contribution); the exafferent path still revokes, labelled distinctly.
- Full suite **1144 passed / 2 skipped across 172 files**, replay-equivalence green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)