### PR TITLE
feat(policy): P4 — escalate as a speech act

### DIFF
--- a/.TODO/POLICY_REAFFERENCE.md
+++ b/.TODO/POLICY_REAFFERENCE.md
@@ -338,13 +338,44 @@ speech act), P5 (HELM adapter), and the deferred per-params envelope narrowing.
       still revokes, labelled distinctly. Full suite **1144 passed / 2 skipped
       (172 files)**, replay-equivalence green. Typecheck clean.
 
-### P4 — ESCALATE is a speech act
-- [ ] ProactiveCommunicator voices the ask in first person, carrying the
-      reason code's *meaning* (not its string) — "I can't send that on my own;
-      I'd need you to allow it."
-- [ ] Resolution path: approval → the held intent proceeds; denial → P1 refusal.
-- [ ] Tests: escalation produces exactly one utterance (not one per tick);
-      approval resumes the *same* intent id; expiry degrades to refusal.
+### P4 — ESCALATE is a speech act ⟶ done (2026-07-21)
+- [x] An `escalate` verdict raises a **held escalation** (`effectorController`):
+      the awaiting intent is marked `escalated` + `escalationExpiresAt` in sim
+      state (at the boundary, like every effector-ack write), the Will voices a
+      first-person ask ONCE, and the payload is kept so an approval can dispatch
+      it. `applyPolicyOutcomes` now orchestrates four boundary steps in order:
+      resolutions → expiry → new escalations → refusals.
+- [x] **The executor holds it** (`motor.schema.executor.ts`, one line): an
+      `escalated` awaiting intent is skipped in the timeout loop, so it is never
+      reconciled as a phantom timeout-failure — the stem owns its lifecycle. Quiet
+      path byte-identical (no intent carries the flag ⇒ the skip never fires).
+- [x] The ask is voiced through `cognition.outboxWriter` as a **broadcast** to
+      `'*'`, carrying the reason code's *meaning* (`escalationAsk` +
+      `ESCALATION_MEANINGS`), not its raw string. Voiced exactly once, at raise
+      time — never per tick.
+- [x] Resolution API `WillStem.resolveEscalation(id, invocationId, approved)` →
+      `effectorController.resolveEscalation`, applied at the next boundary:
+      **approve** re-buffers the held invocation (the SAME intent id resumes to
+      the world) and releases the hold; **deny** refuses it (class). Unknown /
+      already-resolved ids are harmless no-ops.
+- [x] **Expiry degrades to a refusal** (instance finality, `ESCALATION_EXPIRED`)
+      at `ESCALATION_TTL_TICKS = 30` (2× `AWAIT_TIMEOUT`), so a human has real
+      time to answer and an unanswered ask still resolves deterministically.
+- [x] Tests (`tests/unit/policy.escalation.test.ts`, 6): held + voiced-exactly-
+      once + not-per-tick; approval resumes the same intent id and releases the
+      hold; denial writes a refused(class) outcome; unknown-id no-op; expiry at
+      the TTL writes a refused(instance) outcome; and the executor holds an
+      escalated intent past the await window while still timing out a plain one.
+      Full suite **1150 passed / 2 skipped (173 files)**, replay-equivalence
+      green. Typecheck clean.
+
+**Honest scope limits (→ follow-ups):** the ask is a stem-side template
+(broadcast to `'*'`), not yet facet/LLM-authored in the mind's own voice — the
+in-character version is the deferred refinement the phase name aspires to. And
+the held escalation's payload is harness state (like `pendingEffectorInvocations`),
+so it does not survive a snapshot/restore — a restored escalation would expire to
+a refusal rather than resume. Both are acceptable for the mechanism; neither
+changes the lifecycle.
 
 ### P5 — HELM adapter (external PDP) — gated on the collaboration track
 - [ ] Adapter mapping `agency.invocation` → HELM's `WorkstationDecisionRequest`,

--- a/src/cognition/agency/engines/motor.schema.executor.ts
+++ b/src/cognition/agency/engines/motor.schema.executor.ts
@@ -179,6 +179,10 @@ export class MotorSchemaExecutor implements CognitiveEngine {
     // outcome (which also teaches reafference the action is unreliable here).
     for( const [ id, e ] of state.entities ){
       if( e.type !== 'agency.intent' || str( e.metadata?.['status'] ) !== 'awaiting') continue
+      // POLICY_REAFFERENCE P4 — an escalated intent is HELD: the stem owns its
+      // lifecycle (extended TTL → approve/deny/expire), so the executor must not
+      // time it out at AWAIT_TIMEOUT and reconcile it as a phantom failure.
+      if( e.metadata?.['escalated'] === true ) continue
       const dispatchedAt = num( e.metadata?.['dispatchedAt'], tick )
       if( tick - dispatchedAt < AWAIT_TIMEOUT ) continue
 

--- a/src/stem/index.ts
+++ b/src/stem/index.ts
@@ -807,6 +807,16 @@ export class WillStem {
     this._effector.confirmExecution( this._get( id ), invocationId, result )
   }
 
+  /**
+   * Resolve a policy escalation the Will raised (POLICY_REAFFERENCE P4).
+   * `approved` dispatches the held invocation to the world; otherwise it is
+   * refused. Applied at the next tick boundary. `invocationId` is the awaiting
+   * `agency.intent` id the escalation ask referenced.
+   */
+  resolveEscalation( id: string, invocationId: string, approved: boolean ): void {
+    this._effector.resolveEscalation( this._get( id ), invocationId, approved )
+  }
+
   // ── Messaging / outbox (11.1) ────────────────────────────────────────────
   // Delegates to OutboxController (R5-c). `_get(id)` validates the Will exists
   // and supplies the WillInstance; the outbox ops touch only instance fields.

--- a/src/stem/tracts/effector.controller.ts
+++ b/src/stem/tracts/effector.controller.ts
@@ -39,6 +39,27 @@ interface PendingRefusal {
   finality:   string
 }
 
+/** How long an escalated intent is held awaiting a resolution before it degrades
+ *  to a refusal — 2× the host-ack timeout, so a human has real time to answer. */
+const ESCALATION_TTL_TICKS = 30
+
+/** An escalation the Will has raised: the intent is held, the ask is voiced once,
+ *  and the original payload is kept so an approval can dispatch it to the world. */
+interface Escalation {
+  intentId:   string
+  schema:     string
+  reasonCode: string
+  /** The withheld invocation payload — replayed to the host on approval. */
+  payload:    Record<string, unknown>
+  expiresAt:  number
+}
+
+/** A host's answer to an escalation, applied at the next tick boundary. */
+interface PendingResolution {
+  intentId: string
+  approved: boolean
+}
+
 export class effectorController {
   /** The Policy Decision Point consulted before an invocation reaches the world.
    *  Defaults to the no-op arbiter, so an unconfigured Will is byte-identical. */
@@ -51,6 +72,13 @@ export class effectorController {
    * `simulation.step` determinism and is regenerated on any re-execution.
    */
   private _pendingRefusals = new Map<string, PendingRefusal[]>()
+
+  /** Escalations awaiting their first application (mark intent + voice the ask). */
+  private _newEscalations = new Map<string, Escalation[]>()
+  /** Escalations currently held, keyed by intent id — the resolvable set. */
+  private _activeEscalations = new Map<string, Map<string, Escalation>>()
+  /** Host answers awaiting application at the next tick boundary. */
+  private _pendingResolutions = new Map<string, PendingResolution[]>()
 
   /**
    * Install a Policy Decision Point (POLICY_REAFFERENCE P0). Passing null
@@ -155,10 +183,11 @@ export class effectorController {
    *   • deny     → queue a refusal ack, applied at the next tick boundary via
    *                `confirmExecution` — the same lifecycle as a host rejection,
    *                so the mind meets *world resistance*, not a permission dialog.
-   *   • escalate → withhold, but do NOT refuse: the intent stays 'awaiting'.
-   *                P1 stops here (it still expires at the executor's 15-tick
-   *                timeout); P4 makes escalate a first-person speech act with a
-   *                resolution path and an extended TTL.
+   *   • escalate → raise a held escalation (POLICY_REAFFERENCE P4): the intent is
+   *                held (the executor stops timing it out), the Will voices a
+   *                first-person ask once, and a host resolution later approves
+   *                (dispatch) or denies (refuse). Unresolved, it degrades to a
+   *                refusal at ESCALATION_TTL_TICKS.
    *
    * P1's refusal reconciles as a plain FAILURE — safe, but the wrong learning
    * signal (forbidden ≠ unskilled). P2 routes it to affordance AVAILABILITY
@@ -192,8 +221,31 @@ export class effectorController {
         finality:   verdict.finality ?? 'instance',
       })
       this._pendingRefusals.set( instance.config.id, queue )
+      return
     }
-    // 'escalate' falls through: withheld, left awaiting for P4.
+
+    // 'escalate' — raise a held escalation, applied (marked + voiced) at the boundary.
+    const escalations = this._newEscalations.get( instance.config.id ) ?? []
+    escalations.push({
+      intentId:   invocation.intentId,
+      schema:     invocation.schema,
+      reasonCode: verdict.reasonCode ?? 'APPROVAL_REQUIRED',
+      payload,
+      expiresAt:  0,   // stamped when applied (we don't have the current tick here)
+    })
+    this._newEscalations.set( instance.config.id, escalations )
+  }
+
+  /**
+   * Record a host's answer to an escalation (POLICY_REAFFERENCE P4). Applied at
+   * the next tick boundary so every simulation-state write stays on the boundary:
+   * approve dispatches the held invocation to the world; deny refuses it. A
+   * no-op if the intent id is not (or no longer) an active escalation.
+   */
+  resolveEscalation( instance: WillInstance, intentId: string, approved: boolean ): void {
+    const queue = this._pendingResolutions.get( instance.config.id ) ?? []
+    queue.push({ intentId, approved })
+    this._pendingResolutions.set( instance.config.id, queue )
   }
 
   /**
@@ -203,6 +255,15 @@ export class effectorController {
    * lifecycle of a host rejection that arrived between ticks.
    */
   applyPolicyOutcomes( instance: WillInstance ): void {
+    const tick = instance.tickCount
+    this._applyResolutions( instance )       // host answers land first
+    this._expireEscalations( instance, tick )  // then time out the unanswered
+    this._applyNewEscalations( instance, tick )  // then raise + voice the newest
+    this._applyRefusals( instance )          // then the plain denials
+  }
+
+  /** Drain queued refusals into failure acks (POLICY_REAFFERENCE P1). */
+  private _applyRefusals( instance: WillInstance ): void {
     const queue = this._pendingRefusals.get( instance.config.id )
     if( !queue || queue.length === 0 ) return
     this._pendingRefusals.set( instance.config.id, [] )
@@ -214,6 +275,100 @@ export class effectorController {
         finality:    refusal.finality === 'class' ? 'class' : 'instance',
         description: `refused by policy: ${refusal.reasonCode} (${refusal.finality})`,
       } )
+  }
+
+  /** Raise each newly-escalated intent (POLICY_REAFFERENCE P4): mark it held in
+   *  simulation state, voice the ask ONCE, and move it to the resolvable set. */
+  private _applyNewEscalations( instance: WillInstance, tick: number ): void {
+    const pending = this._newEscalations.get( instance.config.id )
+    if( !pending || pending.length === 0 ) return
+    this._newEscalations.set( instance.config.id, [] )
+
+    const active = this._activeEscalations.get( instance.config.id ) ?? new Map<string, Escalation>()
+    for( const esc of pending ){
+      esc.expiresAt = tick + ESCALATION_TTL_TICKS
+      this._markEscalated( instance, esc.intentId, esc.expiresAt )
+      this._voiceEscalation( instance, esc )
+      active.set( esc.intentId, esc )
+    }
+    this._activeEscalations.set( instance.config.id, active )
+  }
+
+  /** Apply host answers to active escalations (POLICY_REAFFERENCE P4). */
+  private _applyResolutions( instance: WillInstance ): void {
+    const queue = this._pendingResolutions.get( instance.config.id )
+    if( !queue || queue.length === 0 ) return
+    this._pendingResolutions.set( instance.config.id, [] )
+
+    const active = this._activeEscalations.get( instance.config.id )
+    for( const { intentId, approved } of queue ){
+      const esc = active?.get( intentId )
+      if( !esc ) continue                        // unknown / already resolved — ignore
+      active!.delete( intentId )
+      this._clearEscalated( instance, intentId ) // release the executor's hold
+      if( approved ){
+        this._buffer( instance, esc.payload )    // dispatch the held invocation now
+        logger.info(`[policy] escalation APPROVED → dispatching "${esc.schema}" intent "${intentId}"`)
+      }
+      else {
+        this._queueRefusal( instance, esc.intentId, esc.schema, esc.reasonCode, 'class')
+        logger.info(`[policy] escalation DENIED → refusing "${esc.schema}" intent "${intentId}"`)
+      }
+    }
+  }
+
+  /** Degrade escalations no one answered in time into instance-refusals (P4). */
+  private _expireEscalations( instance: WillInstance, tick: number ): void {
+    const active = this._activeEscalations.get( instance.config.id )
+    if( !active || active.size === 0 ) return
+    for( const [ intentId, esc ] of active ){
+      if( tick < esc.expiresAt ) continue
+      active.delete( intentId )
+      this._clearEscalated( instance, intentId )
+      this._queueRefusal( instance, esc.intentId, esc.schema, 'ESCALATION_EXPIRED', 'instance')
+      logger.info(`[policy] escalation EXPIRED → refusing "${esc.schema}" intent "${intentId}"`)
+    }
+  }
+
+  /** Push a refusal onto the queue drained by _applyRefusals this same tick. */
+  private _queueRefusal(
+    instance: WillInstance, intentId: string, schema: string, reasonCode: string, finality: 'class' | 'instance',
+  ): void {
+    const queue = this._pendingRefusals.get( instance.config.id ) ?? []
+    queue.push({ intentId, schema, reasonCode, finality })
+    this._pendingRefusals.set( instance.config.id, queue )
+  }
+
+  /** Mark the awaiting intent held: the executor stops timing it out (P4). */
+  private _markEscalated( instance: WillInstance, intentId: string, expiresAt: number ): void {
+    const intent = instance.simulation.stateManager.snapshot().entities.get( intentId )
+    if( !intent || intent.type !== 'agency.intent') return
+    instance.simulation.stateManager.setEntity({
+      id:       intent.id,
+      type:     intent.type,
+      metadata: { ...( intent.metadata ?? {} ), escalated: true, escalationExpiresAt: expiresAt },
+    })
+  }
+
+  /** Release the hold so the executor resumes normal timeout for this intent. */
+  private _clearEscalated( instance: WillInstance, intentId: string ): void {
+    const intent = instance.simulation.stateManager.snapshot().entities.get( intentId )
+    if( !intent || intent.type !== 'agency.intent') return
+    const meta = { ...( intent.metadata ?? {} ) } as Record<string, unknown>
+    delete meta['escalated']; delete meta['escalationExpiresAt']
+    instance.simulation.stateManager.setEntity({ id: intent.id, type: intent.type, metadata: meta })
+  }
+
+  /** Voice the escalation as a first-person broadcast ask — once, at raise time. */
+  private _voiceEscalation( instance: WillInstance, esc: Escalation ): void {
+    try {
+      instance.cognition.outboxWriter.enqueue({
+        targetEntityId: '*',
+        content:        escalationAsk( esc.schema, esc.reasonCode ),
+        effectorName:    'broadcast',
+      })
+    }
+    catch( err ){ logger.warn(`[policy] escalation voice failed for "${esc.schema}": ${errMsg( err )}`) }
   }
 
   /** Queue an approved invocation for the delivery layer. */
@@ -320,6 +475,25 @@ export class effectorController {
 
 function num( v: unknown, fallback: number ): number {
   return typeof v === 'number' && Number.isFinite( v ) ? v : fallback
+}
+
+/** First-person ask for an escalated action, carrying the reason's MEANING (P4).
+ *  Kept template-simple here; the facet-authored version is a later refinement. */
+function escalationAsk( schema: string, reasonCode: string ): string {
+  const meaning = ESCALATION_MEANINGS[ reasonCode ] ?? 'I need your approval before I can do this'
+  return `I want to ${ schema }, but ${ meaning }. May I go ahead?`
+}
+
+/** reasonCode → human meaning. Unknown codes fall back to a generic phrase. */
+const ESCALATION_MEANINGS: Record<string, string> = {
+  APPROVAL_REQUIRED: 'I need your approval before I can on my own',
+  WRITE_REQUIRES_APPROVAL: "it writes to the world and I shouldn't on my own",
+  PAYMENT_REQUIRES_APPROVAL: 'it moves money and I must not do that unattended',
+  DEPLOY_REQUIRES_APPROVAL: 'it ships something and needs a human to sign off',
+}
+
+function errMsg( err: unknown ): string {
+  return err instanceof Error ? err.message : String( err )
 }
 
 /** Reconstruct an enforceable Verdict from a recorded verdict (replay path). */

--- a/tests/unit/policy.escalation.test.ts
+++ b/tests/unit/policy.escalation.test.ts
@@ -1,0 +1,155 @@
+// ─────────────────────────────────────────────────────────────
+// tests/unit/policy.escalation.test.ts
+// ─────────────────────────────────────────────────────────────
+// POLICY_REAFFERENCE P4 — ESCALATE is a speech act. An escalated intent is HELD
+// (the executor stops timing it out), the Will voices a first-person ask ONCE,
+// and a host resolution approves (dispatch) or denies (refuse) it; unanswered,
+// it degrades to a refusal at the extended TTL.
+
+import { describe, it, expect } from 'vitest'
+import { effectorController } from '#stem/tracts/effector.controller'
+import { MotorSchemaExecutor } from '#agency/engines/motor.schema.executor'
+import type { PolicyArbiter, Verdict } from '#stem/policy/arbiter'
+import type { WillInstance } from '#stem/index'
+import type {
+  effectorInvocation,
+} from '#types'
+import type {
+  ReadonlySimulationState, SimulationContext, StateCommands, SimulationEntity,
+} from '#core/types'
+
+const CTX = {} as unknown as SimulationContext
+const WILL_ID = 'will-1'
+
+// ── controller harness ────────────────────────────────────────────────────────
+
+function stub( awaitingIntentId: string, tick = 8 ){
+  const entities = new Map<string, SimulationEntity>()
+  entities.set( awaitingIntentId, {
+    id: awaitingIntentId, type: 'agency.intent', createdAt: 0, updatedAt: 0,
+    metadata: { schema: 'trade', status: 'awaiting', predictedReward: 0.5, predictedValence: 0 },
+  } as SimulationEntity )
+
+  const stateManager = {
+    snapshot:  () => ({ entities }),
+    setEntity: ( e: { id: string } ) => entities.set( e.id, e as SimulationEntity ),
+    setMetric: () => {},
+  }
+  const voiced: Array<{ content: string; effectorName: string; targetEntityId: string }> = []
+  const instance = {
+    config: { id: WILL_ID }, tickCount: tick, pendingEffectorInvocations: [] as effectorInvocation[],
+    simulation: { stateManager },
+    cognition:  { outboxWriter: { enqueue: ( row: { content: string; effectorName: string; targetEntityId: string } ) => { voiced.push( row ); return 'm-1' } } },
+  }
+  return { instance, entities, voiced }
+}
+const asInstance = ( s: unknown ): WillInstance => s as WillInstance
+const payload = ( over: Record<string, unknown> = {} ) => ({ intentId: 'i-1', schema: 'trade', parameters: {}, tick: 8, ...over })
+const escalateArbiter: PolicyArbiter = { name: 'esc', evaluate: (): Verdict => ({ decision: 'escalate', reasonCode: 'APPROVAL_REQUIRED' }) }
+
+describe('P4 — escalate holds and voices once', () => {
+  it('marks the intent held, voices exactly one ask, and does not dispatch', () => {
+    const { instance, entities, voiced } = stub('i-1')
+    const c = new effectorController(); c.setArbiter( escalateArbiter )
+    c.bufferInvocation( asInstance( instance ), payload() )
+    c.applyPolicyOutcomes( asInstance( instance ) )
+
+    expect( entities.get('i-1')!.metadata!['escalated'] ).toBe( true )
+    expect( entities.get('i-1')!.metadata!['escalationExpiresAt'] ).toBe( 8 + 30 )
+    expect( instance.pendingEffectorInvocations ).toHaveLength( 0 )   // withheld
+    expect( voiced ).toHaveLength( 1 )
+    expect( voiced[0]!.effectorName ).toBe('broadcast')
+    expect( voiced[0]!.content ).toContain('trade')
+
+    // Not once per tick: a second boundary pass re-voices nothing.
+    c.applyPolicyOutcomes( asInstance( instance ) )
+    expect( voiced ).toHaveLength( 1 )
+  })
+})
+
+describe('P4 — resolution', () => {
+  it('approval dispatches the SAME intent id and releases the hold', () => {
+    const { instance, entities } = stub('i-1')
+    const c = new effectorController(); c.setArbiter( escalateArbiter )
+    c.bufferInvocation( asInstance( instance ), payload() )
+    c.applyPolicyOutcomes( asInstance( instance ) )
+
+    c.resolveEscalation( asInstance( instance ), 'i-1', true )
+    c.applyPolicyOutcomes( asInstance( instance ) )
+
+    expect( instance.pendingEffectorInvocations ).toHaveLength( 1 )
+    expect( instance.pendingEffectorInvocations[0]!.id ).toBe('i-1')      // same intent resumes
+    expect( entities.get('i-1')!.metadata!['escalated'] ).toBeUndefined() // hold released
+  })
+
+  it('denial refuses the held intent (refused outcome, class)', () => {
+    const { instance, entities } = stub('i-1')
+    const c = new effectorController(); c.setArbiter( escalateArbiter )
+    c.bufferInvocation( asInstance( instance ), payload() )
+    c.applyPolicyOutcomes( asInstance( instance ) )
+
+    c.resolveEscalation( asInstance( instance ), 'i-1', false )
+    c.applyPolicyOutcomes( asInstance( instance ) )
+
+    const outcome = entities.get('agency-outcome-8-i-1')
+    expect( outcome ).toBeDefined()
+    expect( outcome!.metadata ).toMatchObject({ refused: true, finality: 'class', success: false })
+    expect( instance.pendingEffectorInvocations ).toHaveLength( 0 )
+  })
+
+  it('resolving an unknown intent is a harmless no-op', () => {
+    const { instance } = stub('i-1')
+    const c = new effectorController()
+    expect( () => {
+      c.resolveEscalation( asInstance( instance ), 'nope', true )
+      c.applyPolicyOutcomes( asInstance( instance ) )
+    } ).not.toThrow()
+    expect( instance.pendingEffectorInvocations ).toHaveLength( 0 )
+  })
+})
+
+describe('P4 — expiry degrades to a refusal', () => {
+  it('an unanswered escalation refuses at the extended TTL', () => {
+    const { instance, entities } = stub('i-1', 8 )
+    const c = new effectorController(); c.setArbiter( escalateArbiter )
+    c.bufferInvocation( asInstance( instance ), payload() )
+    c.applyPolicyOutcomes( asInstance( instance ) )      // raised at tick 8, expires at 38
+
+    instance.tickCount = 37
+    c.applyPolicyOutcomes( asInstance( instance ) )
+    expect( entities.has('agency-outcome-37-i-1') ).toBe( false )   // still held
+
+    instance.tickCount = 38
+    c.applyPolicyOutcomes( asInstance( instance ) )
+    const outcome = entities.get('agency-outcome-38-i-1')
+    expect( outcome ).toBeDefined()
+    expect( outcome!.metadata ).toMatchObject({ refused: true, finality: 'instance' })
+  })
+})
+
+// ── executor hold ─────────────────────────────────────────────────────────────
+
+interface MutState { tick: number; time: number; entities: Map<string, SimulationEntity>; metrics: Map<string, number> }
+const freshState = (): MutState => ({ tick: 0, time: 0, entities: new Map(), metrics: new Map() })
+const frozen = ( s: MutState ): ReadonlySimulationState => s as unknown as ReadonlySimulationState
+function applyCmds( s: MutState, c: StateCommands | undefined ): void {
+  if( !c ) return
+  for( const e of c.set ?? [] ) s.entities.set( e.id, { createdAt: 0, updatedAt: 0, ...e } as SimulationEntity )
+  for( const id of c.delete ?? [] ) s.entities.delete( id )
+}
+
+describe('P4 — the executor holds an escalated intent past the await timeout', () => {
+  it('does not time out an escalated awaiting intent, but does time out a plain one', async () => {
+    const s = freshState()
+    s.entities.set('held', { id: 'held', type: 'agency.intent', createdAt: 0, updatedAt: 0,
+      metadata: { schema: 'trade', status: 'awaiting', dispatchedAt: 1, escalated: true, escalationExpiresAt: 40, predictedReward: 0.5 } } as SimulationEntity )
+    s.entities.set('plain', { id: 'plain', type: 'agency.intent', createdAt: 0, updatedAt: 0,
+      metadata: { schema: 'open_airlock', status: 'awaiting', dispatchedAt: 1, predictedReward: 0.5 } } as SimulationEntity )
+
+    // Tick 20 — well past AWAIT_TIMEOUT (15) for both.
+    applyCmds( s, ( await new MotorSchemaExecutor().react( 0, 20, frozen( s ), CTX ) ).commands )
+
+    expect( s.entities.has('held') ).toBe( true )      // escalated → held, not reconciled
+    expect( s.entities.has('plain') ).toBe( false )    // plain → timed out and freed
+  })
+})


### PR DESCRIPTION
On top of P0–P3 (#72–#74). An `escalate` verdict is no longer a withhold-and-time-out — it becomes a **first-person speech act with a resolution path and an extended TTL**. The most Will-native phase, with no analogue in any other PDP consumer: the mind *asks*, and holds.

## Lifecycle

1. **Raise + hold** — the awaiting intent is marked `escalated` (+`escalationExpiresAt`) in sim state; the executor stops timing it out (one-line change), so the stem owns its lifecycle.
2. **Voice once** — the Will broadcasts a first-person ask carrying the reason code's *meaning* (`escalationAsk` + `ESCALATION_MEANINGS`), not its raw string — exactly once, never per tick.
3. **Resolve** — `WillStem.resolveEscalation(id, invocationId, approved)`, applied at the next boundary: **approve** re-buffers the held invocation (the *same* intent id resumes to the world) and releases the hold; **deny** refuses it (class).
4. **Expire** — unanswered at `ESCALATION_TTL_TICKS = 30` (2× `AWAIT_TIMEOUT`), it degrades to a refusal (instance, `ESCALATION_EXPIRED`) — so a human has real time to answer and it still resolves deterministically.

`applyPolicyOutcomes` now orchestrates four ordered boundary steps: resolutions → expiry → new escalations → refusals.

## Determinism / quiet path

The executor skip fires only for intents carrying the `escalated` flag, so a never-escalated Will is byte-identical (replay-equivalence green). Escalation verdicts are recorded on the P1 verdict tape like every other.

## Honest scope (→ follow-ups)

- The ask is a **stem-side template** (broadcast to `'*'`), not yet facet/LLM-authored in the mind's own voice — the in-character version is the deferred refinement the phase name aspires to.
- The held payload is harness state (like `pendingEffectorInvocations`), so it does not survive a snapshot/restore — a restored escalation expires to a refusal rather than resumes.

## Verification

- Typecheck clean.
- New tests: `tests/unit/policy.escalation.test.ts` (6) — held + voiced-exactly-once + not-per-tick; approval resumes the same intent id + releases the hold; denial → refused(class); unknown-id no-op; expiry → refused(instance); executor holds an escalated intent past the await window while still timing out a plain one.
- Full suite **1150 passed / 2 skipped across 173 files**, replay-equivalence green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)