### PR TITLE
fix(release): manual Discord announce posts the latest release

### DIFF
--- a/.github/workflows/announce-discord.yml
+++ b/.github/workflows/announce-discord.yml
@@ -26,6 +26,7 @@ jobs:
     steps:
       - name: Post release to Discord
         env:
+          GH_TOKEN:    ${{ github.token }}
           WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           REL_NAME:    ${{ github.event.release.name }}
           REL_TAG:     ${{ github.event.release.tag_name }}
@@ -35,6 +36,17 @@ jobs:
           if [ -z "$WEBHOOK_URL" ]; then
             echo "::notice::DISCORD_WEBHOOK_URL not set — skipping Discord announce."
             exit 0
+          fi
+
+          # Manual dispatch carries no release context — announce the LATEST
+          # published release instead (lets a release that predates the webhook
+          # be announced after the fact).
+          if [ -z "$REL_TAG" ]; then
+            echo "Manually dispatched — announcing the latest published release."
+            eval "$(gh release view --repo "$GITHUB_REPOSITORY" \
+              --json name,tagName,url \
+              --jq '@sh "REL_NAME=\(.name) REL_TAG=\(.tagName) REL_URL=\(.url)"')"
+            REL_BODY="$(gh release view --repo "$GITHUB_REPOSITORY" --json body --jq .body)"
           fi
 
           # Embed description caps at 4096 chars; keep headroom for safety.


### PR DESCRIPTION
A `workflow_dispatch` run has no release context, so it would post an empty embed. Now it resolves the **latest published release** via `gh` — which also makes it possible to back-announce v0.7.0, which predates the `DISCORD_WEBHOOK_URL` secret.

🤖 Generated with [Claude Code](https://claude.com/claude-code)