### PR TITLE
docs: HELM accepts the proposal — reconcile to the 4-value finality enum

### DIFF
--- a/.TODO/ENVELOPE_NARROWING.md
+++ b/.TODO/ENVELOPE_NARROWING.md
@@ -13,6 +13,34 @@
 >
 > Companion reading: `POLICY_REAFFERENCE.md` (P2 — the availability layer this
 > refines; the scope decision it defers to here is recorded there).
+>
+> ---
+>
+> **UPDATE 2026-07-27 — the upstream proposal was ACCEPTED**, returned as the
+> bilateral joint RFC *"Denials That Teach"* (HELM × Will v0.1). HELM ships
+> `counterfactual` on denial receipts, opt-in per policy profile. This item is no
+> longer speculative: it is **the consumer half of a shipped wire field**, and
+> Will is named the reference consumer in HELM's conformance packs. Three
+> consequences for the design below:
+>
+> 1. **`oneOf` is dropped from the HELM path.** Counterfactuals carry *scalar
+>    bounds and required-capability names only — never enumerations*, because an
+>    allowlist is an infrastructure map and a denial that returns it is an
+>    exfiltration primitive. `oneOf` survives only for the local
+>    `RuleTableArbiter`, which is trusted and in-process. The HELM-sourced
+>    envelope is effectively `{ max?, min? }`.
+> 2. **Only `instance_parameter` feeds this layer.** Under the four-value enum
+>    ([[POLICY_REAFFERENCE]] P5), `instance_context` must touch nothing and
+>    `class_forbidden` **erases** stored envelopes — which settles the open
+>    question at the bottom of this file. A required-capability counterfactual is
+>    not envelope knowledge at all; it rides `ungranted` and makes the escalation
+>    ask *specific* ("I need `fs:write`") rather than generic.
+> 3. **Direction is an open upstream ask.** A scalar `allowed` alone cannot
+>    distinguish a ceiling from a floor; a learner that guesses wrong clamps the
+>    wrong way, which is worse than not learning. We asked for either a
+>    `relation: 'max'|'min'|'eq'` field or a guarantee that `requested` is always
+>    present (so direction is recoverable by comparison). **P1 below must not be
+>    implemented until this is settled** — it decides the fold.
 
 ---
 
@@ -75,7 +103,9 @@ it (the world just proved the bound moved).
 
 - **Store:** per-`(schema, field)` bounds in the repertoire —
   `{ max?, min?, oneOf?, lastRefusedTick }` — folded from counterfactuals
-  (numeric `allowed` ⇒ max/min by comparison with `requested`; array ⇒ oneOf).
+  (numeric `allowed` ⇒ max/min by `relation` if upstream supplies it, else by
+  comparison with `requested`; array ⇒ oneOf, **local arbiter only** — HELM never
+  sends enumerations, see the 2026-07-27 update).
   Same lifecycle discipline as availability: empty until fed (byte-identical
   quiet path), slow decay toward open so a relaxed policy is re-discoverable,
   entry dropped when fully open, mirror + restore entities.
@@ -117,9 +147,13 @@ it (the world just proved the bound moved).
 
 - **NOT in scope:** local pre-refusal (the arbiter remains the law); per-target
   envelopes (field-level only, first); surfacing envelopes in Studio.
-- **Open question:** should a `class` refusal also *erase* stored envelopes for
-  the schema (a "never" makes bounds moot), or leave them to decay? Leaning
-  erase — cheaper than carrying dead knowledge.
+- ~~**Open question:** should a `class` refusal also *erase* stored envelopes?~~
+  **SETTLED 2026-07-27 — erase.** The joint RFC's §4 makes it normative
+  consumer behavior for `class_forbidden` ("erase stored envelopes; stop
+  probing"), which matches where we were leaning anyway.
+- **Prerequisite:** [[POLICY_REAFFERENCE]] **P5** (the four-value taxonomy)
+  lands first — this layer must be fed by `instance_parameter` alone, and that
+  value does not exist until P5 widens the enum.
 
 ## Related
 

--- a/.TODO/POLICY_REAFFERENCE.md
+++ b/.TODO/POLICY_REAFFERENCE.md
@@ -21,8 +21,9 @@
 > byte-identical throughout. Verdict vocabulary (`finality` + `counterfactual`,
 > no numeric severity) is deliberately identical to the HELM RFC's proposal.
 >
-> **Open:** **P5** (HELM adapter — gated on the collaboration track; the local
-> `RuleTableArbiter` already exercises the interface). **Deferred refinements:**
+> **Open:** **P5** (the four-value finality taxonomy — *unblocked*, no HELM
+> dependency) and **P6** (HELM transport adapter — gated on the schema diff).
+> **Deferred refinements:**
 > facet-authored escalation voice → [[ESCALATION_VOICE]] (`.TODO/ESCALATION_VOICE.md`);
 > counterfactual-driven envelope narrowing → [[ENVELOPE_NARROWING]]
 > (`.TODO/ENVELOPE_NARROWING.md`); escalation-payload persistence across
@@ -43,6 +44,29 @@
 > collaboration track with its builders. **Nothing here hard-depends on HELM** —
 > the seam is provider-agnostic by construction (§P0). HELM is the first adapter,
 > not the interface.
+>
+> **Collaboration status (2026-07-27): the proposal was accepted and returned as
+> a bilateral joint RFC** — *"Denials That Teach"* (HELM × Will v0.1, Ivan /
+> Fabrice). HELM ships the **producer** half (both receipt fields, opt-in per
+> policy profile, absent when disabled); Will is named the **reference consumer**
+> in HELM's conformance packs. Two things land on us, and both are recorded
+> below as **P5**:
+>
+> 1. **`finality` widens 2 → 4 values**, mechanically derived from the rule that
+>    fired: `class_forbidden` · `ungranted` · `instance_parameter` ·
+>    `instance_context`. Three map onto paths we already shipped; the fourth is
+>    new (see below).
+> 2. **`counterfactual` carries scalar bounds and required-capability names
+>    ONLY — never enumerations**, because an allowlist is an infrastructure map
+>    and a denial that returns it is an exfiltration primitive. This deletes the
+>    `oneOf` branch from [[ENVELOPE_NARROWING]]'s HELM-sourced path.
+>
+> Reply drafted at `Will-HELM/WILL_REPLY_TO_HELM.md` (answers their §7; asks back
+> for counterfactual *direction* — a `relation` field or a `requested` guarantee
+> — since a scalar bound alone cannot distinguish a ceiling from a floor, and a
+> learner that guesses wrong clamps the wrong way).
+> **The picture:** `docs/graphs/policy-joint-rfc.svg` — producer, seam, and the
+> four consumer fates in one diagram.
 
 ---
 
@@ -404,16 +428,65 @@ so it does not survive a snapshot/restore — a restored escalation would expire
 a refusal rather than resume. Both are acceptable for the mechanism; neither
 changes the lifecycle.
 
-### P5 — HELM adapter (external PDP) — gated on the collaboration track
+### P5 — The four-value finality taxonomy — UNBLOCKED (no HELM dependency)
+
+The joint RFC's enum is a **vocabulary**, not a transport. It can be adopted
+entirely against the local `RuleTableArbiter`, and it should be — it is what
+makes the P6 adapter a four-arm switch instead of a semantic negotiation.
+
+- [ ] **Widen `DenialFinality`** to HELM's spelling on the deny branch:
+      `'class_forbidden' | 'instance_parameter' | 'instance_context'`.
+      `ungranted` does **not** join it — it maps to our existing
+      `decision: 'escalate'` (see the axis note below). `finalityOf()`'s
+      conservative default becomes `'instance_parameter'`.
+- [ ] **`instance_context` — the new fate: touch NOTHING.** A context/taint
+      refusal is not about the ability, so denting its availability teaches a
+      lesson the policy never taught. Record the verdict, free the awaiting
+      intent, signal the plan step, and stop — no availability delta, no
+      envelope, no competence. This is a fourth branch in the ReafferenceEngine's
+      refused path, and it **corrects current behaviour**: today every instance
+      denial dents availability by 0.12 regardless of cause.
+- [ ] **Fix the arbiter-fault path (conformance S9 — we currently fail it).**
+      A sync throw / async rejection fails closed correctly (the effect is
+      withheld, `effector.controller.ts:137`) but queues no refusal, so the held
+      intent expires at `AWAIT_TIMEOUT` and reconciles as a **plain failure** —
+      landing on competence. A PDP outage must never teach a mind it is
+      unskilled. Queue an `instance_context`-shaped refusal instead (touch
+      nothing), reason code `ARBITER_UNAVAILABLE`.
+- [ ] Tests: each of the four values drives exactly its own fate and no other
+      (the S1–S9 matrix, minus the transport-dependent ones); `instance_context`
+      leaves availability, envelopes and `LearnedSkill` all provably untouched;
+      an arbiter fault records no competence; quiet path still byte-identical.
+
+**The axis note (recorded, because it will come up again).** HELM is fail-closed,
+so every receipt is allow-or-deny and `ungranted` is a *denial shape* meaning "a
+human could grant this." Will keeps a third **decision** because an escalation is
+not a denial here: the intent is HELD, the timeout clock stops, and an approval
+dispatches **the same intent id** — it is the original reach resumed, not a
+retry. Three of HELM's values are `<scope>_<reason>`; `ungranted` is neither, and
+that asymmetry is the tell that it lives on a different axis. We proposed a
+`resolvable: true` flag orthogonal to a three-value enum (it would also express
+"bound exceeded, but an operator could raise it" — inexpressible today); if
+upstream declines, the four-arm mapping works unchanged.
+
+### P6 — HELM adapter (external PDP) — gated on the schema diff
 - [ ] Adapter mapping `agency.invocation` → HELM's `WorkstationDecisionRequest`,
-      and `WorkstationPolicyDecisionReceipt` → `Verdict`.
+      and `WorkstationPolicyDecisionReceipt` → `Verdict`. With P5 done this is a
+      four-arm switch plus transport.
 - [ ] Transport decision (subprocess CLI vs. `helm-ai-kernel serve` HTTP).
       **Must stay optional** — the OSS engine never hard-depends on a Go binary.
 - [ ] Receipts flow to the record stream, not to cognition (determinism rule 4);
       this is where this document meets `RECORD_ANCHORING.md`.
-- [ ] Upstream asks tracked separately (async correlated verdicts, graded +
-      counterfactual denials, a non-workstation effect taxonomy, a documented
-      deterministic mode). See the collaboration notes, not this file.
+- [ ] **Bilateral-determinism demo** (the joint RFC's §5 centerpiece): a seeded
+      Will against a frozen policy snapshot, replayed tick-for-tick. Our half
+      already holds — verdicts are taped and re-fed, the arbiter is never
+      re-consulted on replay; HELM commits to computing the counterfactual from
+      the same snapshot as the verdict.
+- [ ] **Conformance fixtures S1–S9** contributed upstream (seeded mind + frozen
+      policy snapshot + expected state deltas). S6 (*a relaxed policy is
+      rediscovered without a restart*) is the one worth arguing hardest for: a
+      consumer that zeroes a forbidden ability permanently degenerates back into
+      a static blocklist.
 
 ---
 

--- a/docs/graphs/generate.ts
+++ b/docs/graphs/generate.ts
@@ -1120,6 +1120,77 @@ const graphs: Graph[] = [
       { from: 'select', to: 'revoke', label: 'honored next tick' },
     ],
   },
+
+  // ═══ 24 · THE JOINT RFC (HELM × Will) ═════════════════════
+  {
+    file: 'policy-joint-rfc.svg',
+    title: 'Denials that teach — the HELM × Will seam',
+    subtitle: 'The joint RFC in one picture: a denial carries WHY it is final and WHAT would have worked; four receipt values become four distinct fates in the mind — and competence is never one of them',
+    width: 1360, height: 880,
+    legend: [ 'world', 'infra', 'agency' ],
+    groups: [
+      { x: 44,   y: 118, w: 236,  h: 460, label: 'producer — HELM',   cat: 'world' },
+      { x: 300,  y: 118, w: 236,  h: 460, label: 'the wire',          cat: 'infra' },
+      { x: 556,  y: 118, w: 250,  h: 460, label: 'the seam — will',   cat: 'infra' },
+      { x: 826,  y: 118, w: 250,  h: 560, label: 'four fates — 3 deny · 1 ask',       cat: 'infra' },
+      { x: 1096, y: 118, w: 224,  h: 560, label: 'what the mind learns',              cat: 'agency' },
+      { x: 44,   y: 700, w: 1276, h: 120, label: 'the invariants — what a refusal can never do', cat: 'agency' },
+    ],
+    nodes: [
+      // producer
+      { id: 'rule',     x: 62,   y: 190, w: 200, label: 'The rule that fired',  sub: 'one frozen policy snapshot',        cat: 'world' },
+      { id: 'receipt',  x: 62,   y: 340, w: 200, label: 'Signed receipt',       sub: 'the decision, with evidence',       cat: 'world' },
+      { id: 'profile',  x: 62,   y: 490, w: 200, label: 'Opt-in per profile',   sub: 'absent when off — presence speaks', cat: 'world' },
+      // the wire
+      { id: 'finality', x: 318,  y: 190, w: 200, label: 'finality',             sub: 'WHY it is final — four values',     cat: 'infra' },
+      { id: 'counter',  x: 318,  y: 340, w: 200, label: 'counterfactual',       sub: 'WHAT would have worked',            cat: 'infra' },
+      { id: 'never',    x: 318,  y: 490, w: 200, label: 'never enumerations',   sub: 'an allowlist is an infra map',      cat: 'infra' },
+      // the seam
+      { id: 'adapter',  x: 576,  y: 190, w: 210, label: 'HELM adapter',         sub: 'receipt → Verdict · four arms',     cat: 'infra' },
+      { id: 'pep',      x: 576,  y: 340, w: 210, label: 'effectorController — PEP', sub: 'the one tract every effect crosses', cat: 'infra' },
+      { id: 'tape',     x: 576,  y: 490, w: 210, label: 'Verdict tape',         sub: 'recorded at the tick it arrived',   cat: 'infra' },
+      // four fates
+      { id: 'forbid',   x: 846,  y: 160, w: 210, label: 'class_forbidden',      sub: 'this act, never — let go of it',    cat: 'infra' },
+      { id: 'ungrant',  x: 846,  y: 300, w: 210, label: 'ungranted',            sub: 'no grant — held, not denied',       cat: 'infra' },
+      { id: 'param',    x: 846,  y: 440, w: 210, label: 'instance_parameter',   sub: 'not that much — this much',         cat: 'infra' },
+      { id: 'context',  x: 846,  y: 580, w: 210, label: 'instance_context',     sub: 'not about the act at all',          cat: 'infra' },
+      // what the mind learns
+      { id: 'avail',    x: 1112, y: 160, w: 192, label: 'Availability — may',   sub: 'cut hard · envelopes erased',       cat: 'agency' },
+      { id: 'voice',    x: 1112, y: 300, w: 192, label: 'The ask — voiced once', sub: 'approve ⇒ the same intent resumes', cat: 'agency' },
+      { id: 'envelope', x: 1112, y: 440, w: 192, label: 'Envelope — how much',  sub: 'clamps habit · informs thought',    cat: 'agency' },
+      { id: 'nodelta',  x: 1112, y: 580, w: 192, label: 'No delta at all',      sub: 'record it · free it · touch nothing', cat: 'agency' },
+      // the invariants
+      { id: 'outcome',  x: 62,   y: 730, w: 200, label: 'Real outcomes',        sub: 'the world actually ran it',         cat: 'world' },
+      { id: 'skill',    x: 330,  y: 730, w: 210, label: 'LearnedSkill — can',   sub: 'only these ever write here',        cat: 'agency', glow: true },
+      { id: 'replay',   x: 596,  y: 730, w: 210, label: 'Byte-identical replay', sub: 'tape re-fed · PDP never re-asked', cat: 'infra' },
+      { id: 'probe',    x: 846,  y: 730, w: 210, label: 'Re-probe survives',    sub: 'a relaxed policy is rediscovered',  cat: 'agency' },
+      { id: 'quiet',    x: 1112, y: 730, w: 192, label: 'No policy ⇒ no trace', sub: 'identical to a pre-policy mind',    cat: 'infra' },
+    ],
+    edges: [
+      { from: 'rule',     to: 'receipt' },
+      { from: 'profile',  to: 'receipt',  dash: true, label: 'discloses', fromSide: 't', toSide: 'b' },
+      { from: 'receipt',  to: 'finality', fromSide: 'r', toSide: 'l' },
+      { from: 'receipt',  to: 'counter',  fromSide: 'r', toSide: 'l' },
+      { from: 'never',    to: 'counter',  dash: true, label: 'constrains', fromSide: 't', toSide: 'b' },
+      { from: 'finality', to: 'adapter' },
+      { from: 'counter',  to: 'adapter',  dash: true, at: 0.35 },
+      { from: 'adapter',  to: 'pep',      label: 'Verdict' },
+      { from: 'pep',      to: 'tape',     dash: true, label: 'every verdict' },
+      // The axis collapse: HELM sends four finality values; only `ungranted`
+      // becomes a third DECISION here (held, not denied) — so it is the one
+      // arm worth labelling. The group title carries the 3-deny/1-ask split.
+      { from: 'pep',      to: 'forbid',   fromSide: 'r', toSide: 'l' },
+      { from: 'pep',      to: 'ungrant',  fromSide: 'r', toSide: 'l' },
+      { from: 'pep',      to: 'param',    fromSide: 'r', toSide: 'l' },
+      { from: 'pep',      to: 'context',  fromSide: 'r', toSide: 'l' },
+      { from: 'forbid',   to: 'avail',    fromSide: 'r', toSide: 'l' },
+      { from: 'ungrant',  to: 'voice',    fromSide: 'r', toSide: 'l' },
+      { from: 'param',    to: 'envelope', fromSide: 'r', toSide: 'l' },
+      { from: 'context',  to: 'nodelta',  fromSide: 'r', toSide: 'l' },
+      { from: 'outcome',  to: 'skill' },
+      { from: 'tape',     to: 'replay',   label: 'recorded', fromSide: 'b', toSide: 't' },
+    ],
+  },
 ]
 
 for( const g of graphs ){

--- a/docs/graphs/policy-joint-rfc.svg
+++ b/docs/graphs/policy-joint-rfc.svg
@@ -1,0 +1,218 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1360" height="880" viewBox="0 0 1360 880" font-family="ui-sans-serif,-apple-system,'Segoe UI',Helvetica,Arial,sans-serif">
+<defs>
+<radialGradient id="sky" cx="30%" cy="-10%" r="90%"><stop offset="0%" stop-color="#151b28"/><stop offset="55%" stop-color="#0d1119"/><stop offset="100%" stop-color="#0a0d13"/></radialGradient>
+<filter id="glow" x="-60%" y="-60%" width="220%" height="220%"><feDropShadow dx="0" dy="0" stdDeviation="7" flood-opacity="0.55"/></filter>
+<marker id="arr-e2e8f0" viewBox="0 0 10 10" refX="8.4" refY="5" markerWidth="7.5" markerHeight="7.5" orient="auto-start-reverse"><path d="M 0.8 1.2 L 8.8 5 L 0.8 8.8 L 3 5 Z" fill="#e2e8f0"/></marker>
+<marker id="arr-94a3b8" viewBox="0 0 10 10" refX="8.4" refY="5" markerWidth="7.5" markerHeight="7.5" orient="auto-start-reverse"><path d="M 0.8 1.2 L 8.8 5 L 0.8 8.8 L 3 5 Z" fill="#94a3b8"/></marker>
+</defs>
+<rect width="1360" height="880" fill="url(#sky)"/>
+<rect x="1" y="1" width="1358" height="878" rx="22" fill="none" stroke="#ffffff14" stroke-width="1.5"/>
+<text x="40" y="56" font-size="25" font-weight="700" fill="#f8fafc" letter-spacing="0.2">Denials that teach — the HELM × Will seam</text>
+<text x="40" y="80" font-size="13" fill="#8b93a7">The joint RFC in one picture: a denial carries WHY it is final and WHAT would have worked; four receipt values become four distinct fates in the mind — and competence is never one of them</text>
+<rect x="1196.5" y="42" width="123.5" height="22" rx="11" fill="#4ade8014" stroke="#4ade8055" stroke-width="1"/>
+<circle cx="1208.5" cy="53" r="3.4" fill="#4ade80"/>
+<text x="1217.5" y="57" font-size="10.5" fill="#cbd5e1">Agency (action)</text>
+<rect x="1028.4" y="42" width="160.1" height="22" rx="11" fill="#94a3b814" stroke="#94a3b855" stroke-width="1"/>
+<circle cx="1040.4" cy="53" r="3.4" fill="#94a3b8"/>
+<text x="1049.4" y="57" font-size="10.5" fill="#cbd5e1">Stem / infrastructure</text>
+<rect x="915.2" y="42" width="105.19999999999999" height="22" rx="11" fill="#e2e8f014" stroke="#e2e8f055" stroke-width="1"/>
+<circle cx="927.2" cy="53" r="3.4" fill="#e2e8f0"/>
+<text x="936.2" y="57" font-size="10.5" fill="#cbd5e1">Host / world</text>
+<rect x="44" y="118" width="236" height="460" rx="16" fill="#e2e8f007" stroke="#e2e8f02e" stroke-width="1" stroke-dasharray="5 4"/>
+<text x="60" y="140" font-size="10.5" font-weight="700" letter-spacing="1.6" fill="#e2e8f0bb">PRODUCER — HELM</text>
+<rect x="300" y="118" width="236" height="460" rx="16" fill="#94a3b807" stroke="#94a3b82e" stroke-width="1" stroke-dasharray="5 4"/>
+<text x="316" y="140" font-size="10.5" font-weight="700" letter-spacing="1.6" fill="#94a3b8bb">THE WIRE</text>
+<rect x="556" y="118" width="250" height="460" rx="16" fill="#94a3b807" stroke="#94a3b82e" stroke-width="1" stroke-dasharray="5 4"/>
+<text x="572" y="140" font-size="10.5" font-weight="700" letter-spacing="1.6" fill="#94a3b8bb">THE SEAM — WILL</text>
+<rect x="826" y="118" width="250" height="560" rx="16" fill="#94a3b807" stroke="#94a3b82e" stroke-width="1" stroke-dasharray="5 4"/>
+<text x="842" y="140" font-size="10.5" font-weight="700" letter-spacing="1.6" fill="#94a3b8bb">FOUR FATES — 3 DENY · 1 ASK</text>
+<rect x="1096" y="118" width="224" height="560" rx="16" fill="#4ade8007" stroke="#4ade802e" stroke-width="1" stroke-dasharray="5 4"/>
+<text x="1112" y="140" font-size="10.5" font-weight="700" letter-spacing="1.6" fill="#4ade80bb">WHAT THE MIND LEARNS</text>
+<rect x="44" y="700" width="1276" height="120" rx="16" fill="#4ade8007" stroke="#4ade802e" stroke-width="1" stroke-dasharray="5 4"/>
+<text x="60" y="722" font-size="10.5" font-weight="700" letter-spacing="1.6" fill="#4ade80bb">THE INVARIANTS — WHAT A REFUSAL CAN NEVER DO</text>
+<path d="M 162 244 C 162 280.48, 162 303.52, 162 340" fill="none" stroke="#e2e8f0" stroke-width="1.6" stroke-opacity="0.85" marker-end="url(#arr-e2e8f0)"/>
+<path d="M 162 490 C 162 453.52, 162 430.48, 162 394" fill="none" stroke="#e2e8f0" stroke-width="1.6" stroke-opacity="0.85" stroke-dasharray="5 4" marker-end="url(#arr-e2e8f0)"/>
+<rect x="128.8" y="432" width="66.4" height="19" rx="9.5" fill="#0b0e14" fill-opacity="0.92" stroke="#e2e8f044" stroke-width="0.8"/>
+<text x="162" y="445.5" font-size="10" fill="#cbd5e1" text-anchor="middle">discloses</text>
+<path d="M 262 367 C 322.84273498126134 367, 257.15726501873866 217, 318 217" fill="none" stroke="#e2e8f0" stroke-width="1.6" stroke-opacity="0.85" marker-end="url(#arr-e2e8f0)"/>
+<path d="M 262 367 C 296 367, 284 367, 318 367" fill="none" stroke="#e2e8f0" stroke-width="1.6" stroke-opacity="0.85" marker-end="url(#arr-e2e8f0)"/>
+<path d="M 418 490 C 418 453.52, 418 430.48, 418 394" fill="none" stroke="#94a3b8" stroke-width="1.6" stroke-opacity="0.85" stroke-dasharray="5 4" marker-end="url(#arr-94a3b8)"/>
+<rect x="382" y="432" width="72" height="19" rx="9.5" fill="#0b0e14" fill-opacity="0.92" stroke="#94a3b844" stroke-width="0.8"/>
+<text x="418" y="445.5" font-size="10" fill="#cbd5e1" text-anchor="middle">constrains</text>
+<path d="M 518 217 C 552 217, 542 217, 576 217" fill="none" stroke="#94a3b8" stroke-width="1.6" stroke-opacity="0.85" marker-end="url(#arr-94a3b8)"/>
+<path d="M 518 367 C 579.1126958986429 367, 514.8873041013571 217, 576 217" fill="none" stroke="#94a3b8" stroke-width="1.6" stroke-opacity="0.85" stroke-dasharray="5 4" marker-end="url(#arr-94a3b8)"/>
+<path d="M 681 244 C 681 280.48, 681 303.52, 681 340" fill="none" stroke="#94a3b8" stroke-width="1.6" stroke-opacity="0.85" marker-end="url(#arr-94a3b8)"/>
+<rect x="653.4" y="282" width="55.199999999999996" height="19" rx="9.5" fill="#0b0e14" fill-opacity="0.92" stroke="#94a3b844" stroke-width="0.8"/>
+<text x="681" y="295.5" font-size="10" fill="#cbd5e1" text-anchor="middle">Verdict</text>
+<path d="M 681 394 C 681 430.48, 681 453.52, 681 490" fill="none" stroke="#94a3b8" stroke-width="1.6" stroke-opacity="0.85" stroke-dasharray="5 4" marker-end="url(#arr-94a3b8)"/>
+<rect x="636.6" y="432" width="88.8" height="19" rx="9.5" fill="#0b0e14" fill-opacity="0.92" stroke="#94a3b844" stroke-width="0.8"/>
+<text x="681" y="445.5" font-size="10" fill="#cbd5e1" text-anchor="middle">every verdict</text>
+<path d="M 786 367 C 858.099930651839 367, 773.900069348161 187, 846 187" fill="none" stroke="#94a3b8" stroke-width="1.6" stroke-opacity="0.85" marker-end="url(#arr-94a3b8)"/>
+<path d="M 786 367 C 820 367, 812 327, 846 327" fill="none" stroke="#94a3b8" stroke-width="1.6" stroke-opacity="0.85" marker-end="url(#arr-94a3b8)"/>
+<path d="M 786 367 C 830.3152344008242 367, 801.6847655991758 467, 846 467" fill="none" stroke="#94a3b8" stroke-width="1.6" stroke-opacity="0.85" marker-end="url(#arr-94a3b8)"/>
+<path d="M 786 367 C 880.0068082640827 367, 751.9931917359173 607, 846 607" fill="none" stroke="#94a3b8" stroke-width="1.6" stroke-opacity="0.85" marker-end="url(#arr-94a3b8)"/>
+<path d="M 1056 187 C 1090 187, 1078 187, 1112 187" fill="none" stroke="#94a3b8" stroke-width="1.6" stroke-opacity="0.85" marker-end="url(#arr-94a3b8)"/>
+<path d="M 1056 327 C 1090 327, 1078 327, 1112 327" fill="none" stroke="#94a3b8" stroke-width="1.6" stroke-opacity="0.85" marker-end="url(#arr-94a3b8)"/>
+<path d="M 1056 467 C 1090 467, 1078 467, 1112 467" fill="none" stroke="#94a3b8" stroke-width="1.6" stroke-opacity="0.85" marker-end="url(#arr-94a3b8)"/>
+<path d="M 1056 607 C 1090 607, 1078 607, 1112 607" fill="none" stroke="#94a3b8" stroke-width="1.6" stroke-opacity="0.85" marker-end="url(#arr-94a3b8)"/>
+<path d="M 262 757 C 296 757, 296 757, 330 757" fill="none" stroke="#e2e8f0" stroke-width="1.6" stroke-opacity="0.85" marker-end="url(#arr-e2e8f0)"/>
+<path d="M 681 544 C 681 615.0874278617534, 701 658.9125721382466, 701 730" fill="none" stroke="#94a3b8" stroke-width="1.6" stroke-opacity="0.85" marker-end="url(#arr-94a3b8)"/>
+<rect x="660.6" y="627" width="60.8" height="19" rx="9.5" fill="#0b0e14" fill-opacity="0.92" stroke="#94a3b844" stroke-width="0.8"/>
+<text x="691" y="640.5" font-size="10" fill="#cbd5e1" text-anchor="middle">recorded</text>
+<g>
+<rect x="62" y="190" width="200" height="54" rx="12" fill="#10141d" stroke="#e2e8f099" stroke-width="1.4"/>
+<rect x="62" y="190" width="200" height="54" rx="12" fill="#e2e8f012"/>
+<rect x="63.2" y="199" width="3.2" height="36" rx="1.6" fill="#e2e8f0"/>
+<text x="162" y="214" font-size="13" font-weight="600" fill="#f1f5f9" text-anchor="middle">The rule that fired</text>
+<text x="162" y="230.5" font-size="10" fill="#8b93a7" text-anchor="middle">one frozen policy snapshot</text>
+</g>
+<g>
+<rect x="62" y="340" width="200" height="54" rx="12" fill="#10141d" stroke="#e2e8f099" stroke-width="1.4"/>
+<rect x="62" y="340" width="200" height="54" rx="12" fill="#e2e8f012"/>
+<rect x="63.2" y="349" width="3.2" height="36" rx="1.6" fill="#e2e8f0"/>
+<text x="162" y="364" font-size="13" font-weight="600" fill="#f1f5f9" text-anchor="middle">Signed receipt</text>
+<text x="162" y="380.5" font-size="10" fill="#8b93a7" text-anchor="middle">the decision, with evidence</text>
+</g>
+<g>
+<rect x="62" y="490" width="200" height="54" rx="12" fill="#10141d" stroke="#e2e8f099" stroke-width="1.4"/>
+<rect x="62" y="490" width="200" height="54" rx="12" fill="#e2e8f012"/>
+<rect x="63.2" y="499" width="3.2" height="36" rx="1.6" fill="#e2e8f0"/>
+<text x="162" y="514" font-size="13" font-weight="600" fill="#f1f5f9" text-anchor="middle">Opt-in per profile</text>
+<text x="162" y="530.5" font-size="10" fill="#8b93a7" text-anchor="middle">absent when off — presence speaks</text>
+</g>
+<g>
+<rect x="318" y="190" width="200" height="54" rx="12" fill="#10141d" stroke="#94a3b899" stroke-width="1.4"/>
+<rect x="318" y="190" width="200" height="54" rx="12" fill="#94a3b812"/>
+<rect x="319.2" y="199" width="3.2" height="36" rx="1.6" fill="#94a3b8"/>
+<text x="418" y="214" font-size="13" font-weight="600" fill="#f1f5f9" text-anchor="middle">finality</text>
+<text x="418" y="230.5" font-size="10" fill="#8b93a7" text-anchor="middle">WHY it is final — four values</text>
+</g>
+<g>
+<rect x="318" y="340" width="200" height="54" rx="12" fill="#10141d" stroke="#94a3b899" stroke-width="1.4"/>
+<rect x="318" y="340" width="200" height="54" rx="12" fill="#94a3b812"/>
+<rect x="319.2" y="349" width="3.2" height="36" rx="1.6" fill="#94a3b8"/>
+<text x="418" y="364" font-size="13" font-weight="600" fill="#f1f5f9" text-anchor="middle">counterfactual</text>
+<text x="418" y="380.5" font-size="10" fill="#8b93a7" text-anchor="middle">WHAT would have worked</text>
+</g>
+<g>
+<rect x="318" y="490" width="200" height="54" rx="12" fill="#10141d" stroke="#94a3b899" stroke-width="1.4"/>
+<rect x="318" y="490" width="200" height="54" rx="12" fill="#94a3b812"/>
+<rect x="319.2" y="499" width="3.2" height="36" rx="1.6" fill="#94a3b8"/>
+<text x="418" y="514" font-size="13" font-weight="600" fill="#f1f5f9" text-anchor="middle">never enumerations</text>
+<text x="418" y="530.5" font-size="10" fill="#8b93a7" text-anchor="middle">an allowlist is an infra map</text>
+</g>
+<g>
+<rect x="576" y="190" width="210" height="54" rx="12" fill="#10141d" stroke="#94a3b899" stroke-width="1.4"/>
+<rect x="576" y="190" width="210" height="54" rx="12" fill="#94a3b812"/>
+<rect x="577.2" y="199" width="3.2" height="36" rx="1.6" fill="#94a3b8"/>
+<text x="681" y="214" font-size="13" font-weight="600" fill="#f1f5f9" text-anchor="middle">HELM adapter</text>
+<text x="681" y="230.5" font-size="10" fill="#8b93a7" text-anchor="middle">receipt → Verdict · four arms</text>
+</g>
+<g>
+<rect x="576" y="340" width="210" height="54" rx="12" fill="#10141d" stroke="#94a3b899" stroke-width="1.4"/>
+<rect x="576" y="340" width="210" height="54" rx="12" fill="#94a3b812"/>
+<rect x="577.2" y="349" width="3.2" height="36" rx="1.6" fill="#94a3b8"/>
+<text x="681" y="364" font-size="13" font-weight="600" fill="#f1f5f9" text-anchor="middle">effectorController — PEP</text>
+<text x="681" y="380.5" font-size="10" fill="#8b93a7" text-anchor="middle">the one tract every effect crosses</text>
+</g>
+<g>
+<rect x="576" y="490" width="210" height="54" rx="12" fill="#10141d" stroke="#94a3b899" stroke-width="1.4"/>
+<rect x="576" y="490" width="210" height="54" rx="12" fill="#94a3b812"/>
+<rect x="577.2" y="499" width="3.2" height="36" rx="1.6" fill="#94a3b8"/>
+<text x="681" y="514" font-size="13" font-weight="600" fill="#f1f5f9" text-anchor="middle">Verdict tape</text>
+<text x="681" y="530.5" font-size="10" fill="#8b93a7" text-anchor="middle">recorded at the tick it arrived</text>
+</g>
+<g>
+<rect x="846" y="160" width="210" height="54" rx="12" fill="#10141d" stroke="#94a3b899" stroke-width="1.4"/>
+<rect x="846" y="160" width="210" height="54" rx="12" fill="#94a3b812"/>
+<rect x="847.2" y="169" width="3.2" height="36" rx="1.6" fill="#94a3b8"/>
+<text x="951" y="184" font-size="13" font-weight="600" fill="#f1f5f9" text-anchor="middle">class_forbidden</text>
+<text x="951" y="200.5" font-size="10" fill="#8b93a7" text-anchor="middle">this act, never — let go of it</text>
+</g>
+<g>
+<rect x="846" y="300" width="210" height="54" rx="12" fill="#10141d" stroke="#94a3b899" stroke-width="1.4"/>
+<rect x="846" y="300" width="210" height="54" rx="12" fill="#94a3b812"/>
+<rect x="847.2" y="309" width="3.2" height="36" rx="1.6" fill="#94a3b8"/>
+<text x="951" y="324" font-size="13" font-weight="600" fill="#f1f5f9" text-anchor="middle">ungranted</text>
+<text x="951" y="340.5" font-size="10" fill="#8b93a7" text-anchor="middle">no grant — held, not denied</text>
+</g>
+<g>
+<rect x="846" y="440" width="210" height="54" rx="12" fill="#10141d" stroke="#94a3b899" stroke-width="1.4"/>
+<rect x="846" y="440" width="210" height="54" rx="12" fill="#94a3b812"/>
+<rect x="847.2" y="449" width="3.2" height="36" rx="1.6" fill="#94a3b8"/>
+<text x="951" y="464" font-size="13" font-weight="600" fill="#f1f5f9" text-anchor="middle">instance_parameter</text>
+<text x="951" y="480.5" font-size="10" fill="#8b93a7" text-anchor="middle">not that much — this much</text>
+</g>
+<g>
+<rect x="846" y="580" width="210" height="54" rx="12" fill="#10141d" stroke="#94a3b899" stroke-width="1.4"/>
+<rect x="846" y="580" width="210" height="54" rx="12" fill="#94a3b812"/>
+<rect x="847.2" y="589" width="3.2" height="36" rx="1.6" fill="#94a3b8"/>
+<text x="951" y="604" font-size="13" font-weight="600" fill="#f1f5f9" text-anchor="middle">instance_context</text>
+<text x="951" y="620.5" font-size="10" fill="#8b93a7" text-anchor="middle">not about the act at all</text>
+</g>
+<g>
+<rect x="1112" y="160" width="192" height="54" rx="12" fill="#10141d" stroke="#4ade8099" stroke-width="1.4"/>
+<rect x="1112" y="160" width="192" height="54" rx="12" fill="#4ade8012"/>
+<rect x="1113.2" y="169" width="3.2" height="36" rx="1.6" fill="#4ade80"/>
+<text x="1208" y="184" font-size="13" font-weight="600" fill="#f1f5f9" text-anchor="middle">Availability — may</text>
+<text x="1208" y="200.5" font-size="10" fill="#8b93a7" text-anchor="middle">cut hard · envelopes erased</text>
+</g>
+<g>
+<rect x="1112" y="300" width="192" height="54" rx="12" fill="#10141d" stroke="#4ade8099" stroke-width="1.4"/>
+<rect x="1112" y="300" width="192" height="54" rx="12" fill="#4ade8012"/>
+<rect x="1113.2" y="309" width="3.2" height="36" rx="1.6" fill="#4ade80"/>
+<text x="1208" y="324" font-size="13" font-weight="600" fill="#f1f5f9" text-anchor="middle">The ask — voiced once</text>
+<text x="1208" y="340.5" font-size="10" fill="#8b93a7" text-anchor="middle">approve ⇒ the same intent resumes</text>
+</g>
+<g>
+<rect x="1112" y="440" width="192" height="54" rx="12" fill="#10141d" stroke="#4ade8099" stroke-width="1.4"/>
+<rect x="1112" y="440" width="192" height="54" rx="12" fill="#4ade8012"/>
+<rect x="1113.2" y="449" width="3.2" height="36" rx="1.6" fill="#4ade80"/>
+<text x="1208" y="464" font-size="13" font-weight="600" fill="#f1f5f9" text-anchor="middle">Envelope — how much</text>
+<text x="1208" y="480.5" font-size="10" fill="#8b93a7" text-anchor="middle">clamps habit · informs thought</text>
+</g>
+<g>
+<rect x="1112" y="580" width="192" height="54" rx="12" fill="#10141d" stroke="#4ade8099" stroke-width="1.4"/>
+<rect x="1112" y="580" width="192" height="54" rx="12" fill="#4ade8012"/>
+<rect x="1113.2" y="589" width="3.2" height="36" rx="1.6" fill="#4ade80"/>
+<text x="1208" y="604" font-size="13" font-weight="600" fill="#f1f5f9" text-anchor="middle">No delta at all</text>
+<text x="1208" y="620.5" font-size="10" fill="#8b93a7" text-anchor="middle">record it · free it · touch nothing</text>
+</g>
+<g>
+<rect x="62" y="730" width="200" height="54" rx="12" fill="#10141d" stroke="#e2e8f099" stroke-width="1.4"/>
+<rect x="62" y="730" width="200" height="54" rx="12" fill="#e2e8f012"/>
+<rect x="63.2" y="739" width="3.2" height="36" rx="1.6" fill="#e2e8f0"/>
+<text x="162" y="754" font-size="13" font-weight="600" fill="#f1f5f9" text-anchor="middle">Real outcomes</text>
+<text x="162" y="770.5" font-size="10" fill="#8b93a7" text-anchor="middle">the world actually ran it</text>
+</g>
+<g filter="url(#glow)" color="#4ade80">
+<rect x="330" y="730" width="210" height="54" rx="12" fill="#10141d" stroke="#4ade8099" stroke-width="1.4"/>
+<rect x="330" y="730" width="210" height="54" rx="12" fill="#4ade8012"/>
+<rect x="331.2" y="739" width="3.2" height="36" rx="1.6" fill="#4ade80"/>
+<text x="435" y="754" font-size="13" font-weight="600" fill="#f1f5f9" text-anchor="middle">LearnedSkill — can</text>
+<text x="435" y="770.5" font-size="10" fill="#8b93a7" text-anchor="middle">only these ever write here</text>
+</g>
+<g>
+<rect x="596" y="730" width="210" height="54" rx="12" fill="#10141d" stroke="#94a3b899" stroke-width="1.4"/>
+<rect x="596" y="730" width="210" height="54" rx="12" fill="#94a3b812"/>
+<rect x="597.2" y="739" width="3.2" height="36" rx="1.6" fill="#94a3b8"/>
+<text x="701" y="754" font-size="13" font-weight="600" fill="#f1f5f9" text-anchor="middle">Byte-identical replay</text>
+<text x="701" y="770.5" font-size="10" fill="#8b93a7" text-anchor="middle">tape re-fed · PDP never re-asked</text>
+</g>
+<g>
+<rect x="846" y="730" width="210" height="54" rx="12" fill="#10141d" stroke="#4ade8099" stroke-width="1.4"/>
+<rect x="846" y="730" width="210" height="54" rx="12" fill="#4ade8012"/>
+<rect x="847.2" y="739" width="3.2" height="36" rx="1.6" fill="#4ade80"/>
+<text x="951" y="754" font-size="13" font-weight="600" fill="#f1f5f9" text-anchor="middle">Re-probe survives</text>
+<text x="951" y="770.5" font-size="10" fill="#8b93a7" text-anchor="middle">a relaxed policy is rediscovered</text>
+</g>
+<g>
+<rect x="1112" y="730" width="192" height="54" rx="12" fill="#10141d" stroke="#94a3b899" stroke-width="1.4"/>
+<rect x="1112" y="730" width="192" height="54" rx="12" fill="#94a3b812"/>
+<rect x="1113.2" y="739" width="3.2" height="36" rx="1.6" fill="#94a3b8"/>
+<text x="1208" y="754" font-size="13" font-weight="600" fill="#f1f5f9" text-anchor="middle">No policy ⇒ no trace</text>
+<text x="1208" y="770.5" font-size="10" fill="#8b93a7" text-anchor="middle">identical to a pre-policy mind</text>
+</g>
+<text x="40" y="858" font-size="10.5" fill="#5b6372">@mindot/will · policy-joint-rfc</text>
+<text x="1320" y="858" font-size="10.5" fill="#454c59" text-anchor="end">regenerate: bun docs/graphs/generate.ts</text>
+</svg>


### PR DESCRIPTION
Mindburn returned our upstream proposal as a **bilateral joint RFC** — *"Denials That Teach"* (HELM × Will v0.1). HELM ships the **producer** half (both receipt fields, opt-in per policy profile, absent when disabled) and names Will the **reference consumer** in their conformance packs.

Docs-only: two `.TODO` specs reconciled, one new graph. No source changes.

## What lands on us

**1 · `finality` widens 2 → 4 values**, derived from the rule that fired:

| HELM finality | Will's fate | status |
| :--- | :--- | :--- |
| `class_forbidden` | availability cut + envelopes erased + deliberation released | shipped 0.7.0 |
| `ungranted` | held → first-person ask → approve/deny/expire | shipped 0.7.0 |
| `instance_parameter` | envelope recorded, reach clamped | ENVELOPE_NARROWING |
| `instance_context` | **touch nothing** | **new** |

`instance_context` **corrects current behaviour**. Today every instance denial dents availability by 0.12 regardless of cause — but a context/taint refusal isn't about the ability, so denting it teaches a lesson the policy never taught.

**2 · `counterfactual` carries scalar bounds and required-capability names only — never enumerations**, because an allowlist is an infrastructure map and a denial that returns it is an exfiltration primitive. This deletes the `oneOf` branch from ENVELOPE_NARROWING's HELM-sourced path, and settles its open question normatively (`class_forbidden` erases stored envelopes).

## Resequenced

**P5 is now the taxonomy adoption and is unblocked today** — the enum is a *vocabulary, not a transport*, so it lands entirely against the local `RuleTableArbiter`. The HELM transport adapter becomes **P6**, still gated on the schema diff. With P5 done, P6 is a four-arm switch rather than a semantic negotiation.

## A conformance gap found while drafting the scenario list

We fail our own proposed **S9**. An arbiter fault fails closed correctly (the effect is withheld) but queues no refusal — so the held intent expires at `AWAIT_TIMEOUT` and reconciles as a *plain failure*, landing on competence. **A PDP outage must never teach a mind it is unskilled.** Folded into P5.

## The picture

`docs/graphs/policy-joint-rfc.svg` (graph 24) — producer, wire, seam, the four fates, and what each teaches. In the invariants band, `LearnedSkill` has no incoming edge from any denial path. That absence is the argument.

## Open upstream

A scalar `allowed` alone can't distinguish a ceiling from a floor, and a learner that guesses wrong clamps the wrong way. We've asked for either a `relation: 'max'|'min'|'eq'` field or a guarantee that `requested` is always present. **ENVELOPE_NARROWING P1 is blocked on that answer** — it decides the fold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)