### PR TITLE
chore: split commercial phases out of the public engine roadmap

### DIFF
--- a/.TODO/ENGINE_PHASES.md
+++ b/.TODO/ENGINE_PHASES.md
@@ -1,4 +1,10 @@
-# Roadmap: Self-Aware Simulated Mind Framework
+# Engine Phases: Self-Aware Simulated Mind Framework
+
+> **Internal engineering history.** The phase-by-phase build record of the
+> engine, kept for provenance. The forward-looking, community-facing roadmap is
+> [ROADMAP.md](../ROADMAP.md). Commercial phases — billing, pricing, margins,
+> enterprise packaging — are tracked outside this repository and must not be
+> re-added here: `.TODO/` is fully git-tracked and therefore public.
 
 ## Overview
 
@@ -35,9 +41,8 @@ entity that persists across time.
 | 13.6 | MCP + A2A | **0%** | Not started. |
 | 13.7 | Comm-layer hardening | **~50%** | ack + delivered endpoints exist; ChannelRouter partial. |
 | 13.8 | 5 Senses | **~85%** | Audition full; 4 shells; conversation pipeline rebuilt; API live. |
-| 14 | Billing & monetization | **~80%** | LemonSqueezy + credits + ledger live. Paystack deferred. |
-| 15 | Self-hosted LLM | **~5%** | Tracker prices DeepSeek; no GPU deploy. |
-| 16 / 17 | Research / Enterprise | **0%** | Correctly post-revenue. |
+| 14 / 15 / 17 | Commercial phases | — | Tracked outside this repository. |
+| 16 | Research platform | **0%** | Publication + community commitments; correctly post-revenue. |
 | 18 | Cognitive quality | **~15%** | pgvector (3.2) landed early; rest deferred. |
 | 19 | Architecture evolution (event bus, GWT, active inference) | **~35%, built early** | See callout below. |
 
@@ -553,7 +558,7 @@ The fitness function is derived from the agent's identity values:
 - [ ] `POST /wills/:id/tune` — manually adjust engine parameters (admin)
 
 ### 13.2 API Infrastructure
-- [ ] Authentication via API keys (Stripe integration)
+- [ ] Authentication via API keys (issued on subscription activation)
 - [ ] Rate limiting per key per tier
 - [ ] Usage metering (ticks, tokens, storage, API calls)
 - [ ] Webhook events: `will.created`, `will.tick_completed`, `will.cost_threshold`
@@ -880,78 +885,20 @@ matching, no session continuity, zero durability.
 
 ---
 
-## Phase 14: Billing & Monetization 🔄 ~80%
+## Phases 14–15: Commercial
 
-> See `MONETIZATION.md` for full pricing strategy. **Plans re-baselined to v3
-> (2026-06-20): Starter $19 / Pro $199 / Enterprise $1,500+ — no free plan.**
-
-### 14.1 Billing Provider Strategy 🔄
-- [x] **Primary: Lemon Squeezy** — Merchant of Record for global customers
-  - Handles VAT/GST, sales tax, chargebacks, invoicing
-  - Pays out via bank transfer to Wise multi-currency account
-  - 5% + $0.50/transaction
-- [ ] **Secondary: Paystack** — African payment methods (deferred to v1.1)
-  - Nigeria, Ghana, South Africa, Kenya coverage
-  - 1.5% + local fees
-- [x] **Payout**: Lemon Squeezy → Wise (USD) → local currency at interbank rates
-
-### 14.2 Stripe Alternative Implementation ✅
-- [x] Lemon Squeezy product catalog: **Starter, Pro, Enterprise** (v3)
-- [x] Subscription lifecycle webhooks: created, updated, cancelled, refunded
-- [x] API key generation on subscription activation (own keys, not provider keys)
-- [x] API key revocation on subscription cancellation
-- [ ] Usage-based overage tracking (`whOverageCents` seeded; metering job pending)
-
-### 14.3 Customer Portal ✅
-- [x] Usage dashboard: Wills created, ticks processed, tokens consumed, costs
-- [x] API key management (create, rotate, revoke)
-- [x] Plan comparison and upgrade flow via Lemon Squeezy checkout
-- [x] Billing history and invoice download
-
-### 14.4 Internal Cost Monitoring
-- [ ] Per-customer profitability: revenue - (LLM costs + infra costs)
-- [ ] Cost anomaly detection: sudden spikes trigger investigation
-- [ ] Model cost arbitrage tracking: when to route to cheaper models
-- [ ] Margin dashboard: gross margin per tier, per customer, per model
-- [ ] Regional payout reconciliation: Lemon Squeezy → Wise → Local
-
----
-
-## Phase 15: Self-Hosted LLM Infrastructure
-
-> Migration from external API providers to self-hosted models for
-> margin expansion and control.
-
-### 15.1 Stage 1: Evaluation
-- [ ] Benchmark DeepSeek V3, Llama 4, Qwen 3 on structured output tasks
-- [ ] Compare token costs vs GPT-4o/Claude at current usage patterns
-- [ ] Evaluate fine-tuning potential on custom schemas
-
-### 15.2 Stage 2: Hybrid Deployment
-- [ ] Deploy selected model on 1-2 GPUs (RunPod, Vast.ai, or dedicated)
-- [ ] Route simple queries to self-hosted, complex/novel to external
-- [ ] A/B test: self-hosted vs external quality for each engine
-- [ ] Gross margin target: 80% (up from ~73%)
-
-### 15.3 Stage 3: Self-Sufficient
-- [ ] Dedicated GPU cluster for production inference
-- [ ] Fine-tuned models on structured output schemas
-- [ ] Speculative decoding optimized for cognitive engine prompts
-- [ ] External providers as overflow/fallback only
-- [ ] Gross margin target: 90%+
+> **Billing & monetization** (14) and **self-hosted LLM infrastructure** (15)
+> are commercial phases. They are tracked outside this repository, with the
+> rest of the business material. The numbers are kept here so the phase
+> sequence stays stable across the documents that reference it.
 
 ---
 
 ## Phase 16: Research Platform
 
-> Open the architecture to academic researchers. Runs in parallel with
-> commercial API — same infrastructure, different pricing model.
-
-### 16.1 Academic Access
-- [ ] Free tier for verified .edu emails (limited agents, public data only)
-- [ ] Grant-funded bulk pricing for large-scale simulations
-- [ ] Dataset export: anonymized agent behavior traces for analysis
-- [ ] Collaboration pipeline: researchers submit engine configs, run experiments
+> Open the architecture to academic researchers. Runs on the same
+> infrastructure as the hosted API. Access terms and academic pricing (16.1)
+> are tracked outside this repository; the public commitments are below.
 
 ### 16.2 Publication Support
 - [ ] White paper: "A 36-Engine Cognitive Architecture for Persistent AI Agents"
@@ -968,20 +915,8 @@ matching, no session continuity, zero durability.
 
 ## Phase 17: Enterprise & Vertical SaaS
 
-> White-label and industry-specific deployments.
-
-### 17.1 Enterprise Features
-- [ ] SSO (SAML/OIDC), RBAC, audit logs
-- [ ] On-premise deployment option
-- [ ] Custom model fine-tuning per customer
-- [ ] SLA (99.9% uptime for Shards 0-2, 99.5% for LLM shards)
-- [ ] Dedicated support and onboarding
-
-### 17.2 Vertical Packages
-- [ ] **Gaming**: Unity/Unreal SDK, NPC behavior packs, world integration docs
-- [ ] **Healthcare**: HIPAA-compliant deployment, companion agent templates
-- [ ] **Education**: Tutor agent with curriculum tracking, SIS integration
-- [ ] **Elder Care**: Companionship agent with family alerting, mood tracking
+> Enterprise packaging and industry-specific deployments. Commercial phase —
+> tracked outside this repository.
 
 ---
 
@@ -1269,10 +1204,8 @@ Social (Shard 1)
 | 13.6 | Platform Interoperability (MCP + A2A) | 📋 0% | Phase 13 |
 | 13.7 | Communication Layer Hardening | 🔄 ~50% | Phase 13 |
 | 13.8 | Perceptual Tier — 5 Senses Architecture | ✅ ~85% | Phase 13, 13.7 |
-| 14 | Billing & Monetization | 🔄 ~80% | Phase 13 |
-| 15 | Self-Hosted LLM | 📋 ~5% | Phase 11 |
+| 14 / 15 / 17 | Commercial phases | — | Tracked outside this repository |
 | 16 | Research Platform | 📋 Planned | Parallel with 13-15 |
-| 17 | Enterprise & Vertical SaaS | 📋 Planned | Post-revenue |
 | 18 | Cognitive Quality Improvements | 🔄 ~15% | Phase 11+ |
 | 19-A | Event Bus & Schema Registry | 🔄 partial (publishes/subscribes) | Phase 10 |
 | 19-B | DAG Scheduler | 📋 Post-revenue | Phase 19-A |
@@ -1296,9 +1229,6 @@ before the architecture and market signal are clear enough to justify them.
 | Hard memory deletion (GDPR) | Required before any EU deployment — track separately as a legal/infrastructure item, not a cognitive feature |
 | Google OAuth | v1.1 |
 | Teams / organisations / multi-user accounts | v1.1 |
-| Paystack (African payment methods) | v1.1 |
-| Self-hosted LLM infrastructure | After first revenue (Phase 15) |
-| On-premise / enterprise deployment | Phase 17 |
 | Self-fine-tuning / ParameterOptimizer | Phase 12 — after 50+ customers with real usage data |
 | Multi-node distributed Will execution | Phase 9 multi-node staging — infrastructure exists, not yet plumbed |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,215 @@
+# Will — Roadmap
+
+**How this engine grows, and how you can shape it.**
+
+Will is an engine for persistent machine minds. This document is the public
+roadmap: what exists today, what is being built, what is being considered, and
+what we have deliberately decided *not* to do.
+
+It is written for the people who use and contribute to Will. It is honest by
+construction — every item carries a status, and nothing is listed as coming
+unless it is genuinely being worked on.
+
+- **Discussions & proposals:** [GitHub Discussions](https://github.com/mindot-ai/will/discussions)
+- **Issues & bugs:** [GitHub Issues](https://github.com/mindot-ai/will/issues)
+- **Contributing:** [CONTRIBUTING.md](CONTRIBUTING.md) · [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
+- **Release history:** [CHANGELOG.md](CHANGELOG.md)
+
+---
+
+## How to read this
+
+Every item carries one of three statuses. We do not move an item up a level to
+make the roadmap look better.
+
+| Status | Meaning |
+| :--- | :--- |
+| **Shipped** | In a released version. Documented, tested, and covered by the stability policy below. |
+| **Building** | Actively being worked on. Landing in a foreseeable release. Design may still change. |
+| **Considering** | A direction we find compelling. **Not committed, not scheduled**, and may never happen. Your input matters most here. |
+
+There is no "coming soon." If it is not **Building**, do not plan around it.
+
+---
+
+## What Will is (and isn't)
+
+Will is a **cognitive substrate**, not a chatbot framework and not an agent
+orchestration library. Its distinguishing commitments:
+
+- **An LLM is one component, not the substrate.** Most ticks resolve on the
+  engines alone. The model is recruited when a moment is ambiguous or
+  high-stakes — often it stays silent.
+- **The mind accretes.** Traits develop, beliefs consolidate, skills
+  proceduralise. A coherent self carries across restarts.
+- **Determinism is a first-class property.** Same seed + same inputs
+  re-executes the whole mind byte-for-byte. This is what makes emergent
+  behavior debuggable rather than merely impressive.
+
+Those three commitments are the frame for everything below. A proposed feature
+that would compromise determinism, or that would make the LLM the substrate,
+will be declined on principle — see [Non-goals](#non-goals).
+
+---
+
+## Stability & versioning
+
+Will is pre-1.0 and uses semantic versioning.
+
+- **Minor versions (0.x.0) may contain breaking changes.** They are always
+  documented in [CHANGELOG.md](CHANGELOG.md) with a migration note.
+- **The SDK facade is the stable surface.** If you build on the facade, you are
+  on the most stable path. Deep imports into engine internals are supported for
+  research and extension, but internals move faster.
+- **Determinism is treated as a contract, not a feature.** A change that breaks
+  replay-equivalence is treated as a defect, and a bug report proving one is one
+  of the most valuable contributions you can make.
+- **Toward 1.0:** the criteria are a stable facade surface, a documented
+  extension API for third-party engines, and a published determinism test
+  harness. No date — 1.0 lands when those are true.
+
+---
+
+## Shipped
+
+The foundation. Available today in the released package.
+
+### The mind
+
+- **40+ cognitive engines** — 38 faculties across seven systems (regulatory,
+  perceptual, affective, memory, executive, meta-cognitive, social) stepping
+  forward on a deterministic tick clock.
+- **Agency pipeline** — actions are found in the situation, enacted, and
+  proceduralised into composite skills. Not a fixed effector catalog.
+- **Affective system** — eight evaluators blended into valence, arousal,
+  dominance, and attachment.
+- **Memory** — episodic consolidation, semantic belief integration, forgetting
+  curve, spaced repetition, dream replay.
+- **Planning as a prior** — plans bias the single action competition top-down
+  rather than running a parallel command channel.
+- **Metacognition loop** — introspection writes back into the engine apparatus,
+  bounded and surprise-gated.
+- **Five sensory channels** with a conversation pipeline built on executive
+  facets.
+
+### Continuity & verification
+
+- **PMA (Portable Mind Artifact)** — a portable, eval-verified mind artifact
+  carrying psychology *and* learned competence, with a measured
+  reconstruction-fidelity score.
+- **Deterministic replay** — record a session, replay it, compare runs.
+- **Snapshot / restore** across the full engine set.
+
+### Recent releases
+
+- **0.7.0 — policy reafference.** A Will can be given a boundary deciding what
+  it may enact, and the boundary is *felt* rather than announced: a refusal
+  arrives as world resistance through the same channel as any other
+  consequence, so the mind learns availability without learning incompetence.
+- **0.6.0 — exafference.** The mind distinguishes its own echo from the world.
+  Self-caused percepts are attenuated; genuinely world-caused shifts can
+  interrupt an in-flight commitment. Engagement became dependent on situation
+  shifts, not just on initial choice.
+- **0.5.0 / 0.4.0 — channels.** WhatsApp and Discord surfaces; a choice of
+  executive provider.
+
+### Surfaces you can embed today
+
+SDK facade (Node/TS) · Discord · WhatsApp · MCP server (Claude Desktop / Claude
+Code) · MCP tools as the mind's abilities · HTTP sidecar / Docker for any
+language. See the [README](README.md) for the current list and setup.
+
+---
+
+## Building
+
+Actively in progress.
+
+### Record anchoring — tamper-evident cognition
+
+Cognition records — session logs, decision records, completion transcripts —
+hash-chained inside the engine, digested and signed so that what a mind decided
+can be verified after the fact without trusting the operator.
+
+**Why it matters:** Will can already *explain* a decision by replaying it. This
+adds the missing middle step — proving the record wasn't altered between the
+decision and the explanation. Together: an ability that was never granted can't
+be enacted, what happened is evidenced, and why it happened can be re-derived.
+
+**Community-facing outcome:** an anchored record you can verify yourself, with
+a CLI, independent of any hosted service.
+
+### Determinism test harness
+
+Making replay-equivalence something contributors can run and extend, not just
+something maintainers assert. This is a prerequisite for 1.0.
+
+### Engine quality & cost work
+
+Ongoing: context assembly efficiency, cheaper routing for background cognition,
+and reducing the inference needed per tick without reducing what the mind does.
+
+---
+
+## Considering
+
+**Not committed.** These are directions we find compelling and are actively
+gathering input on. If one matters to you, say so in
+[Discussions](https://github.com/mindot-ai/will/discussions) — real demand is
+how these move.
+
+| Direction | What it would be | What would move it |
+| :--- | :--- | :--- |
+| **Third-party engine API** | A documented, supported way to write your own faculty and have it participate in the tick loop as a first-class engine | Contributors actually building engines against internals today, and telling us where the seams hurt |
+| **Additional language SDK** | A first-class surface beyond Node/TS | Sustained demand concentrated in one language community |
+| **Game-engine integration** | A supported path for embedding a persistent mind in an NPC, with an example project | Game developers building this and reporting what's missing |
+| **Local / edge execution** | Running a mind where there is no cloud — mostly reflexive, reaching for a model rarely | Demand from privacy-first and offline builders, plus local model quality reaching the executive bar |
+| **Cross-surface continuity** | Moving one mind between surfaces with its memory and dispositions intact | Users independently asking to move an existing Will between surfaces |
+| **Populations of minds** | Many persistent minds interacting, with replay making population-scale behavior debuggable | Researchers hitting the ceiling of single-mind deployments |
+
+---
+
+## Non-goals
+
+Deliberate decisions, not gaps. Knowing what a project refuses is as useful as
+knowing what it plans.
+
+- **Not a chatbot framework.** If you want prompt → response, there are lighter
+  tools and you should use them.
+- **Not an agent orchestration library.** Will is one mind, coherent over time —
+  not a graph of task-executing workers.
+- **We will not make the LLM the substrate.** Recruiting a model for every tick
+  would be simpler and would destroy the thing that makes Will different.
+- **We will not trade away determinism** for a feature, however convenient.
+  Replay-equivalence is the property the whole architecture is built to
+  protect.
+- **PMA is for synthetic minds only.** A PMA is the distilled persona of a
+  synthetic mind. It is not a human mind, an upload, or a representation of a
+  real person, and we will not build in that direction.
+- **No speculation mechanics.** No tokens, no NFTs, no artificial scarcity
+  layered onto mind artifacts.
+
+---
+
+## How the roadmap changes
+
+This document is reviewed as the project reaches its own milestones — not on a
+calendar.
+
+**How to influence it:**
+
+1. **Open a Discussion** for a direction, a use case, or a missing seam. The
+   *Considering* table above moves primarily on demonstrated need.
+2. **Open an Issue** for defects. A bug report that breaks replay-equivalence
+   is the highest-value report in this project — it will be prioritized, not
+   deflected.
+3. **Contribute.** See [CONTRIBUTING.md](CONTRIBUTING.md). Engine work,
+   examples, docs, and adapters are all genuinely useful, and the areas under
+   *Considering* are the most open to being shaped by whoever shows up.
+
+Will is developed by [Mindot](https://mindot.io) and released under
+Apache-2.0. The engine is open source and intended to stay that way.
+
+---
+
+*Last updated: 2026-07-28 · engine version 0.7.0*

--- a/src/cognition/memory/vector.embedder.ts
+++ b/src/cognition/memory/vector.embedder.ts
@@ -55,7 +55,7 @@ export class OpenAICompatibleEmbedder implements EmbeddingProvider {
     /**
      * Per-Will token tracker. When provided, each embedding call records its
      * input-token usage under the 'embedding' category so memory-vector spend is
-     * visible alongside LLM spend instead of being a silent COGS leak.
+     * visible alongside LLM spend instead of being a silent cost leak.
      */
     tokenTracker?: TokenTracker | null
   } ){

--- a/src/stem/mind.ts
+++ b/src/stem/mind.ts
@@ -359,17 +359,17 @@ export interface MindAssembly {
   outbox:               OutboxMessage[]
 }
 
-// ── Cadence defaults per tier ─────────────────────────────────
+// ── Named executive cadences ──────────────────────────────────
 
 /**
  * Named executive cadences — ticks between LLM calls. Lower = reasons more often
- * (more responsive, higher COGS). Customers pick via `config.executiveInterval`
- * (clamped to `minExecutiveInterval`). See monetization.md "Cost Per Will-Hour".
+ * (more responsive, more tokens per Will-hour). Callers pick via
+ * `config.executiveInterval` (clamped to `minExecutiveInterval`).
  */
 export const EXECUTIVE_CADENCE = {
-  responsive: 30,  // Sonnet — premium/Enterprise; opt in via executiveInterval
-  balanced:   60,  // Sonnet — Pro default
-  economy:    90,  // Haiku  — Starter default
+  responsive: 30,  // most attentive, highest spend — opt in via executiveInterval
+  balanced:   60,  // default
+  economy:    90,  // least attentive, lowest spend
 } as const
 
 


### PR DESCRIPTION
Public-repo hygiene sweep. `roadmap.md` was git-tracked at the repo root and carried internal commercial material; `.TODO/` is fully git-tracked as well, so relocating it there does not make it private.

## What moves

The commercial phases are removed from the public engine history and now live in the private workspace alongside the pricing and cost model:

| Removed | Was |
| :--- | :--- |
| Phase 14 | Billing provider strategy — provider fees, payout routing, plan prices |
| Phase 14.4 | Internal cost monitoring — per-customer profitability, margin dashboard, model cost arbitrage |
| Phase 15 | Self-hosted LLM — gross-margin targets |
| Phase 16.1 | Academic access terms and grant pricing |
| Phase 17 | Enterprise packaging and vertical bundles |

Phase numbers are kept as stubs so the sequence stays stable for the documents that reference it. **Phases 16.2 and 16.3 stay** — white paper, open-source core, benchmark suite, conference targets, Discord, tutorials, and the engine development guide are public commitments and belong here.

## What else changed

- `roadmap.md` → `.TODO/ENGINE_PHASES.md`, retitled as the internal engineering history it is, with a note that `.TODO/` is public.
- New `ROADMAP.md` — the forward-looking, community-facing roadmap.
- `src/stem/mind.ts` — the `EXECUTIVE_CADENCE` comments mapped plan tiers to concrete models (`Sonnet — Pro default`, `Haiku — Starter default`) and cited an internal pricing doc by name. Per-tier model routing is a margin lever. Cadence values and their cost trade-off are unchanged; only the commercial framing goes.
- `src/cognition/memory/vector.embedder.ts` — "COGS leak" → "cost leak".

## Audit

Swept the tracked tree for `margin`, `pricing`, `Lemon Squeezy`, `Paystack`, `MRR`, `COGS`, and `profitability`. After this change the only remaining hits are legitimate: vendor **list** prices in `README.md` / `CHANGELOG.md` / `docs/channels/discord.md` (public information, and the point of the model-cost comparison), the token tracker's pricing table, and usage-metering language. Those stay.

No behavior change — comments and docs only. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)