### PR TITLE
docs: adopt HELM's distinctions, not HELM's spellings

### DIFF
--- a/.TODO/POLICY_REAFFERENCE.md
+++ b/.TODO/POLICY_REAFFERENCE.md
@@ -52,10 +52,12 @@
 > in HELM's conformance packs. Two things land on us, and both are recorded
 > below as **P5**:
 >
-> 1. **`finality` widens 2 → 4 values**, mechanically derived from the rule that
->    fired: `class_forbidden` · `ungranted` · `instance_parameter` ·
->    `instance_context`. Three map onto paths we already shipped; the fourth is
->    new (see below).
+> 1. **`finality` widens 2 → 4 values on the wire**, mechanically derived from
+>    the rule that fired: `class_forbidden` · `ungranted` · `instance_parameter`
+>    · `instance_context`. Three map onto paths we already shipped; the fourth is
+>    new (see below). **We adopt the distinctions, not the spellings** — our
+>    enum goes `'class' | 'parameter' | 'context'` and HELM's names live in the
+>    P6 adapter alone (P5's naming-boundary note has the full argument).
 > 2. **`counterfactual` carries scalar bounds and required-capability names
 >    ONLY — never enumerations**, because an allowlist is an infrastructure map
 >    and a denial that returns it is an exfiltration primitive. This deletes the
@@ -428,35 +430,86 @@ so it does not survive a snapshot/restore — a restored escalation would expire
 a refusal rather than resume. Both are acceptable for the mechanism; neither
 changes the lifecycle.
 
-### P5 — The four-value finality taxonomy — UNBLOCKED (no HELM dependency)
+### P5 — The finality taxonomy, provider-neutral — UNBLOCKED (no HELM dependency)
 
-The joint RFC's enum is a **vocabulary**, not a transport. It can be adopted
-entirely against the local `RuleTableArbiter`, and it should be — it is what
-makes the P6 adapter a four-arm switch instead of a semantic negotiation.
+The joint RFC's enum is a **vocabulary**, not a transport, so it can be adopted
+entirely against the local `RuleTableArbiter`. **We adopt HELM's DISTINCTIONS,
+not HELM's SPELLINGS** — see the naming-boundary note below, which is the
+load-bearing decision of this phase.
 
-- [ ] **Widen `DenialFinality`** to HELM's spelling on the deny branch:
-      `'class_forbidden' | 'instance_parameter' | 'instance_context'`.
-      `ungranted` does **not** join it — it maps to our existing
-      `decision: 'escalate'` (see the axis note below). `finalityOf()`'s
-      conservative default becomes `'instance_parameter'`.
-- [ ] **`instance_context` — the new fate: touch NOTHING.** A context/taint
-      refusal is not about the ability, so denting its availability teaches a
-      lesson the policy never taught. Record the verdict, free the awaiting
-      intent, signal the plan step, and stop — no availability delta, no
-      envelope, no competence. This is a fourth branch in the ReafferenceEngine's
-      refused path, and it **corrects current behaviour**: today every instance
-      denial dents availability by 0.12 regardless of cause.
+- [ ] **Centralize first.** The literal `'class' | 'instance'` is hand-written
+      in six places instead of importing `DenialFinality`
+      (`reconcile.learning.ts:34`, `repertoire.ts:126`,
+      `effector.controller.ts:335` + `:422`, plus string compares in
+      `reafference.engine.ts:204` and `action.selector.ts:660`). Import the type
+      everywhere **before** widening it — that turns the split below into a
+      compile error at every site that needs attention, instead of six silent
+      mis-routes.
+- [ ] **Split `DenialFinality`** `'class' | 'instance'` →
+      `'class' | 'parameter' | 'context'`. `'class'` is UNCHANGED, so all of
+      P0–P4's code and tests keep working; only `'instance'` splits in two.
+      `ungranted` does not join the enum at all — it maps to our existing
+      `decision: 'escalate'` (see the axis note).
+- [ ] **`context` — the new fate: touch NOTHING.** A context/taint refusal is
+      not about the ability, so denting its availability teaches a lesson the
+      policy never taught. Record the verdict, free the awaiting intent, signal
+      the plan step, and stop — no availability delta, no envelope, no
+      competence. A fourth branch in the ReafferenceEngine's refused path, and
+      it **corrects current behaviour**: today every instance denial dents
+      availability by 0.12 regardless of cause.
+- [ ] **`finalityOf()`'s default stays at `'parameter'` — NEVER `'context'`.**
+      The intuitive read (default to the fate that does least) is wrong here.
+      `context` means *the mind learns nothing from this denial*, so it
+      re-probes the wall forever — the exact failure this epoch exists to fix,
+      silently re-enabled for any provider that doesn't tag. `context` is a
+      claim only a provider that actually knows can make: **assert it, never
+      default to it.** `parameter` (light dent, fast recovery) preserves today's
+      unlabelled-denial behaviour exactly.
 - [ ] **Fix the arbiter-fault path (conformance S9 — we currently fail it).**
       A sync throw / async rejection fails closed correctly (the effect is
       withheld, `effector.controller.ts:137`) but queues no refusal, so the held
       intent expires at `AWAIT_TIMEOUT` and reconciles as a **plain failure** —
       landing on competence. A PDP outage must never teach a mind it is
-      unskilled. Queue an `instance_context`-shaped refusal instead (touch
-      nothing), reason code `ARBITER_UNAVAILABLE`.
-- [ ] Tests: each of the four values drives exactly its own fate and no other
-      (the S1–S9 matrix, minus the transport-dependent ones); `instance_context`
-      leaves availability, envelopes and `LearnedSkill` all provably untouched;
-      an arbiter fault records no competence; quiet path still byte-identical.
+      unskilled. Queue a `context`-shaped refusal instead (touch nothing),
+      reason code `ARBITER_UNAVAILABLE`.
+- [ ] Tests: each value drives exactly its own fate and no other (the S1–S9
+      matrix, minus the transport-dependent ones); `context` leaves
+      availability, envelopes and `LearnedSkill` all provably untouched; an
+      unlabelled denial still behaves exactly as `'instance'` did; an arbiter
+      fault records no competence; quiet path still byte-identical.
+
+**The naming-boundary note (the decision of this phase).** HELM's spellings
+(`class_forbidden` · `ungranted` · `instance_parameter` · `instance_context`)
+live in the **P6 adapter and nowhere else**. `stem/policy/arbiter.ts` is the
+interface EVERY provider implements — its own header promises "no vendor types"
+— and a partner's vocabulary in our published API would make their schema churn
+our breaking change. Three reasons this is not a retreat from the collaboration:
+
+1. **Conformance is behavioural, not nominal.** Their §4 is *value | meaning |
+   consumer behavior*; §5 certifies a mind that *learns* from a denial. We
+   consume their values **verbatim on the wire** and satisfy the behaviour
+   table. Nothing in the RFC asks a consumer how to spell its internal types.
+2. **Our independence is what makes the certification mean anything.** A
+   consumer that mirrors the producer's vocabulary proves the standard works
+   for producer-shaped consumers — nearly circular. An independently-designed
+   mind whose two-axis model *predates* the RFC satisfying the table is
+   evidence the standard is portable. Mirroring would spend that evidence.
+3. **We are consumer #1, so we set the template.** "Map at your boundary,
+   satisfy the table" is cheap to adopt; "adopt our enum into your core types"
+   is not. The cheap pattern is in HELM's interest.
+
+Mitigations, all cheap and all owed: the map is **total and exhaustive** (a new
+HELM value must be a compile error, never a silent fallthrough — that is the
+real failure mode); the map is **published as normative in the joint RFC**, not
+a private detail; and the S1–S9 fixtures assert on **observable state deltas**,
+never on our type names.
+
+**The asymmetry that decides it:** their §7 open item #1 is *"Enum naming"* —
+the names are not final, and we ourselves proposed deleting one. Neutral-now is
+reversible (alias in later at no cost if the names settle and mirroring proves
+worth it); vendor-names-now is not (un-baking a partner's spelling from a
+published Apache-2.0 API breaks every host). Take the reversible path while the
+other side's schema is still moving.
 
 **The axis note (recorded, because it will come up again).** HELM is fail-closed,
 so every receipt is allow-or-deny and `ungranted` is a *denial shape* meaning "a
@@ -472,7 +525,9 @@ upstream declines, the four-arm mapping works unchanged.
 ### P6 — HELM adapter (external PDP) — gated on the schema diff
 - [ ] Adapter mapping `agency.invocation` → HELM's `WorkstationDecisionRequest`,
       and `WorkstationPolicyDecisionReceipt` → `Verdict`. With P5 done this is a
-      four-arm switch plus transport.
+      four-arm switch plus transport. **This file is the ONLY place HELM's enum
+      spellings appear** — total and exhaustive, so a new upstream value is a
+      compile error rather than a silent fallthrough.
 - [ ] Transport decision (subprocess CLI vs. `helm-ai-kernel serve` HTTP).
       **Must stay optional** — the OSS engine never hard-depends on a Go binary.
 - [ ] Receipts flow to the record stream, not to cognition (determinism rule 4);

--- a/docs/graphs/generate.ts
+++ b/docs/graphs/generate.ts
@@ -1132,7 +1132,7 @@ const graphs: Graph[] = [
       { x: 44,   y: 118, w: 236,  h: 460, label: 'producer — HELM',   cat: 'world' },
       { x: 300,  y: 118, w: 236,  h: 460, label: 'the wire',          cat: 'infra' },
       { x: 556,  y: 118, w: 250,  h: 460, label: 'the seam — will',   cat: 'infra' },
-      { x: 826,  y: 118, w: 250,  h: 560, label: 'four fates — 3 deny · 1 ask',       cat: 'infra' },
+      { x: 826,  y: 118, w: 250,  h: 560, label: 'wire value → our fate',            cat: 'infra' },
       { x: 1096, y: 118, w: 224,  h: 560, label: 'what the mind learns',              cat: 'agency' },
       { x: 44,   y: 700, w: 1276, h: 120, label: 'the invariants — what a refusal can never do', cat: 'agency' },
     ],
@@ -1146,14 +1146,14 @@ const graphs: Graph[] = [
       { id: 'counter',  x: 318,  y: 340, w: 200, label: 'counterfactual',       sub: 'WHAT would have worked',            cat: 'infra' },
       { id: 'never',    x: 318,  y: 490, w: 200, label: 'never enumerations',   sub: 'an allowlist is an infra map',      cat: 'infra' },
       // the seam
-      { id: 'adapter',  x: 576,  y: 190, w: 210, label: 'HELM adapter',         sub: 'receipt → Verdict · four arms',     cat: 'infra' },
+      { id: 'adapter',  x: 576,  y: 190, w: 210, label: 'HELM adapter',         sub: 'the only place HELM names live',    cat: 'infra' },
       { id: 'pep',      x: 576,  y: 340, w: 210, label: 'effectorController — PEP', sub: 'the one tract every effect crosses', cat: 'infra' },
       { id: 'tape',     x: 576,  y: 490, w: 210, label: 'Verdict tape',         sub: 'recorded at the tick it arrived',   cat: 'infra' },
       // four fates
-      { id: 'forbid',   x: 846,  y: 160, w: 210, label: 'class_forbidden',      sub: 'this act, never — let go of it',    cat: 'infra' },
-      { id: 'ungrant',  x: 846,  y: 300, w: 210, label: 'ungranted',            sub: 'no grant — held, not denied',       cat: 'infra' },
-      { id: 'param',    x: 846,  y: 440, w: 210, label: 'instance_parameter',   sub: 'not that much — this much',         cat: 'infra' },
-      { id: 'context',  x: 846,  y: 580, w: 210, label: 'instance_context',     sub: 'not about the act at all',          cat: 'infra' },
+      { id: 'forbid',   x: 846,  y: 160, w: 210, label: 'class_forbidden',      sub: '→ class · let go of it',            cat: 'infra' },
+      { id: 'ungrant',  x: 846,  y: 300, w: 210, label: 'ungranted',            sub: '→ escalate · held, not denied',     cat: 'infra' },
+      { id: 'param',    x: 846,  y: 440, w: 210, label: 'instance_parameter',   sub: '→ parameter · not that, this much', cat: 'infra' },
+      { id: 'context',  x: 846,  y: 580, w: 210, label: 'instance_context',     sub: '→ context · not about the act',     cat: 'infra' },
       // what the mind learns
       { id: 'avail',    x: 1112, y: 160, w: 192, label: 'Availability — may',   sub: 'cut hard · envelopes erased',       cat: 'agency' },
       { id: 'voice',    x: 1112, y: 300, w: 192, label: 'The ask — voiced once', sub: 'approve ⇒ the same intent resumes', cat: 'agency' },

--- a/docs/graphs/policy-joint-rfc.svg
+++ b/docs/graphs/policy-joint-rfc.svg
@@ -25,7 +25,7 @@
 <rect x="556" y="118" width="250" height="460" rx="16" fill="#94a3b807" stroke="#94a3b82e" stroke-width="1" stroke-dasharray="5 4"/>
 <text x="572" y="140" font-size="10.5" font-weight="700" letter-spacing="1.6" fill="#94a3b8bb">THE SEAM — WILL</text>
 <rect x="826" y="118" width="250" height="560" rx="16" fill="#94a3b807" stroke="#94a3b82e" stroke-width="1" stroke-dasharray="5 4"/>
-<text x="842" y="140" font-size="10.5" font-weight="700" letter-spacing="1.6" fill="#94a3b8bb">FOUR FATES — 3 DENY · 1 ASK</text>
+<text x="842" y="140" font-size="10.5" font-weight="700" letter-spacing="1.6" fill="#94a3b8bb">WIRE VALUE → OUR FATE</text>
 <rect x="1096" y="118" width="224" height="560" rx="16" fill="#4ade8007" stroke="#4ade802e" stroke-width="1" stroke-dasharray="5 4"/>
 <text x="1112" y="140" font-size="10.5" font-weight="700" letter-spacing="1.6" fill="#4ade80bb">WHAT THE MIND LEARNS</text>
 <rect x="44" y="700" width="1276" height="120" rx="16" fill="#4ade8007" stroke="#4ade802e" stroke-width="1" stroke-dasharray="5 4"/>
@@ -106,7 +106,7 @@
 <rect x="576" y="190" width="210" height="54" rx="12" fill="#94a3b812"/>
 <rect x="577.2" y="199" width="3.2" height="36" rx="1.6" fill="#94a3b8"/>
 <text x="681" y="214" font-size="13" font-weight="600" fill="#f1f5f9" text-anchor="middle">HELM adapter</text>
-<text x="681" y="230.5" font-size="10" fill="#8b93a7" text-anchor="middle">receipt → Verdict · four arms</text>
+<text x="681" y="230.5" font-size="10" fill="#8b93a7" text-anchor="middle">the only place HELM names live</text>
 </g>
 <g>
 <rect x="576" y="340" width="210" height="54" rx="12" fill="#10141d" stroke="#94a3b899" stroke-width="1.4"/>
@@ -127,28 +127,28 @@
 <rect x="846" y="160" width="210" height="54" rx="12" fill="#94a3b812"/>
 <rect x="847.2" y="169" width="3.2" height="36" rx="1.6" fill="#94a3b8"/>
 <text x="951" y="184" font-size="13" font-weight="600" fill="#f1f5f9" text-anchor="middle">class_forbidden</text>
-<text x="951" y="200.5" font-size="10" fill="#8b93a7" text-anchor="middle">this act, never — let go of it</text>
+<text x="951" y="200.5" font-size="10" fill="#8b93a7" text-anchor="middle">→ class · let go of it</text>
 </g>
 <g>
 <rect x="846" y="300" width="210" height="54" rx="12" fill="#10141d" stroke="#94a3b899" stroke-width="1.4"/>
 <rect x="846" y="300" width="210" height="54" rx="12" fill="#94a3b812"/>
 <rect x="847.2" y="309" width="3.2" height="36" rx="1.6" fill="#94a3b8"/>
 <text x="951" y="324" font-size="13" font-weight="600" fill="#f1f5f9" text-anchor="middle">ungranted</text>
-<text x="951" y="340.5" font-size="10" fill="#8b93a7" text-anchor="middle">no grant — held, not denied</text>
+<text x="951" y="340.5" font-size="10" fill="#8b93a7" text-anchor="middle">→ escalate · held, not denied</text>
 </g>
 <g>
 <rect x="846" y="440" width="210" height="54" rx="12" fill="#10141d" stroke="#94a3b899" stroke-width="1.4"/>
 <rect x="846" y="440" width="210" height="54" rx="12" fill="#94a3b812"/>
 <rect x="847.2" y="449" width="3.2" height="36" rx="1.6" fill="#94a3b8"/>
 <text x="951" y="464" font-size="13" font-weight="600" fill="#f1f5f9" text-anchor="middle">instance_parameter</text>
-<text x="951" y="480.5" font-size="10" fill="#8b93a7" text-anchor="middle">not that much — this much</text>
+<text x="951" y="480.5" font-size="10" fill="#8b93a7" text-anchor="middle">→ parameter · not that, this much</text>
 </g>
 <g>
 <rect x="846" y="580" width="210" height="54" rx="12" fill="#10141d" stroke="#94a3b899" stroke-width="1.4"/>
 <rect x="846" y="580" width="210" height="54" rx="12" fill="#94a3b812"/>
 <rect x="847.2" y="589" width="3.2" height="36" rx="1.6" fill="#94a3b8"/>
 <text x="951" y="604" font-size="13" font-weight="600" fill="#f1f5f9" text-anchor="middle">instance_context</text>
-<text x="951" y="620.5" font-size="10" fill="#8b93a7" text-anchor="middle">not about the act at all</text>
+<text x="951" y="620.5" font-size="10" fill="#8b93a7" text-anchor="middle">→ context · not about the act</text>
 </g>
 <g>
 <rect x="1112" y="160" width="192" height="54" rx="12" fill="#10141d" stroke="#4ade8099" stroke-width="1.4"/>


### PR DESCRIPTION
Corrects P5 as merged in #83, which said to *widen `DenialFinality` to HELM's spelling*. That would put a partner's vocabulary into [`stem/policy/arbiter.ts`](https://github.com/mindot-ai/will/blob/main/src/stem/policy/arbiter.ts) — the interface **every** provider implements, whose own header promises *"no vendor types"* — and would make their schema churn our breaking change.

Docs-only. No source changes; typecheck clean.

## The change

```
stem (provider-neutral)     adapter owns the map (P6)
─────────────────────────   ──────────────────────────────────
'class'      ← unchanged    class_forbidden    → deny + 'class'
'parameter'  ← new split    instance_parameter → deny + 'parameter'
'context'    ← new split    instance_context   → deny + 'context'
                            ungranted          → escalate
```

`'class'` doesn't move, so all of P0–P4's code and tests keep working — only `'instance'` divides. HELM's spellings live in the P6 adapter and nowhere else, as a **total exhaustive switch** so a new upstream value is a compile error rather than a silent fallthrough.

## Why this still honors the joint RFC

**Conformance there is behavioural, not nominal.** Their §4 is `value | meaning | consumer behavior`; §5 certifies a mind that *learns* from a denial. We consume their values **verbatim on the wire** and satisfy the behaviour table. Nothing in the RFC asks a consumer how to spell its internal types. (Sent upstream for explicit confirmation — it's now agenda item 3.)

Two further arguments, both *for* the pack rather than against it:

1. **Our independence is what makes the certification mean anything.** A consumer that mirrors the producer's vocabulary proves the standard works for producer-shaped consumers — nearly circular. Will's two-axis model *predates* this RFC; an independently-designed mind satisfying their table is the evidence the standard is **portable**. Mirroring would spend that evidence.
2. **We're consumer #1, so we set the template.** "Map at your boundary, satisfy the table" is cheap to adopt; "adopt our enum into your core types" is not. The cheap template spreads the standard faster.

Mitigations owed and recorded: the map is total and exhaustive; it gets **published as normative in the RFC** rather than kept as our private detail; S1–S9 assert on observable state deltas, never on our type names.

**The asymmetry that decides it:** their §7 open item #1 is *"Enum naming"* — the names aren't final, and we ourselves proposed deleting one. Neutral-now is reversible (alias in later at no cost). Vendor-names-now is not — un-baking a partner's spelling from a published Apache-2.0 API breaks every host.

## Two other P5 corrections

**Centralize the finality literal *before* widening.** It's hand-written in six places instead of importing `DenialFinality` — `reconcile.learning.ts:34`, `repertoire.ts:126`, `effector.controller.ts:335` + `:422`, plus string compares in `reafference.engine.ts:204` and `action.selector.ts:660`. Importing first turns the split into a compile error at every site that needs attention, instead of six silent mis-routes.

**`finalityOf()`'s default stays `'parameter'` — never `'context'`.** The intuitive read (default to the fate that does least) is wrong: `context` means *the mind learns nothing from this denial*, so it re-probes the wall forever — the exact failure this epoch exists to fix, silently re-enabled for any provider that doesn't tag. `context` is a claim only a provider that actually knows can make: **assert it, never default to it.**

## Graph

Updated to match — the adapter node is now *"the only place HELM names live"* and each fate shows the wire value translating into our vocabulary, so the naming boundary is visible rather than implied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)