### PR TITLE
test(policy): the "Denials That Teach" conformance pack, S1–S9

### DIFF
--- a/tests/conformance/denials-that-teach.test.ts
+++ b/tests/conformance/denials-that-teach.test.ts
@@ -1,0 +1,361 @@
+// ─────────────────────────────────────────────────────────────
+// tests/conformance/denials-that-teach.test.ts
+// ─────────────────────────────────────────────────────────────
+// Will's implementation of the HELM × Will conformance pack. The scenarios
+// themselves live in `scenarios.ts` — language-neutral, serializable, and the
+// half we contribute upstream. This file proves Will satisfies them.
+//
+// Everything here asserts OBSERVABLE STATE, never a type name: availability,
+// competence, what reached the world, what was recorded. That is the point —
+// a consumer conforms by behaving correctly, whatever it calls things inside.
+//
+// Verdicts are written in HELM's WIRE spelling and pushed through `helmAdapter`
+// below, which is the four-arm map the P6 transport will reuse verbatim. So the
+// pack exercises the translation too, not just the fates behind it.
+
+import { describe, it, expect, afterEach } from 'vitest'
+import { SCENARIOS, packSummary, type Scenario } from './scenarios'
+import { SchemaRepertoire } from '#agency/schemas/repertoire'
+import { ReafferenceEngine } from '#agency/engines/reafference.engine'
+import { scoreAffordance, DEFAULT_WEIGHTS } from '#agency/selection.scoring'
+import { effectorController } from '#stem/tracts/effector.controller'
+import {
+  setVerdictRecorder, clearVerdictRecorder,
+  setVerdictSource, clearVerdictSource, RecordedVerdictSource,
+  type PolicyVerdictRecord,
+} from '#stem/policy/verdict.recorder'
+import type { PolicyArbiter, Verdict } from '#stem/policy/arbiter'
+import type { WillInstance } from '#stem/index'
+import type { effectorInvocation } from '#types'
+import type {
+  ReadonlySimulationState, SimulationContext, StateCommands, SimulationEntity,
+} from '#core/types'
+import type { Affordance } from '#agency/types'
+
+const WILL_ID = 'conformance-will'
+const CTX     = {} as unknown as SimulationContext
+const SCHEMA  = 'trade'
+
+// ── the wire → Will map (the P6 adapter, in miniature) ───────────────────────
+//
+// HELM's four finality values become Will's two axes. This is the ONLY place
+// HELM's spellings appear; everything downstream speaks Will's vocabulary.
+
+type HelmFinality = 'class_forbidden' | 'ungranted' | 'instance_parameter' | 'instance_context'
+
+function helmAdapter( finality: HelmFinality, reasonCode = 'POLICY', counterfactual?: Verdict['counterfactual'] ): Verdict {
+  switch( finality ){
+    case 'ungranted':          return { decision: 'escalate', reasonCode }
+    case 'class_forbidden':    return { decision: 'deny', reasonCode, finality: 'class' }
+    case 'instance_context':   return { decision: 'deny', reasonCode, finality: 'context' }
+    case 'instance_parameter': return { decision: 'deny', reasonCode, finality: 'parameter',
+                                        ...( counterfactual ? { counterfactual } : {} ) }
+  }
+}
+
+// ── harnesses ────────────────────────────────────────────────────────────────
+
+interface MutState { tick: number; time: number; entities: Map<string, SimulationEntity>; metrics: Map<string, number> }
+const freshState = (): MutState => ({ tick: 0, time: 0, entities: new Map(), metrics: new Map() })
+const frozen = ( s: MutState ): ReadonlySimulationState => s as unknown as ReadonlySimulationState
+
+function apply( s: MutState, c: StateCommands | undefined ): void {
+  if( !c ) return
+  for( const e of c.set ?? [] ) s.entities.set( e.id, { createdAt: 0, updatedAt: 0, ...e } as SimulationEntity )
+  for( const id of c.delete ?? [] ) s.entities.delete( id )
+  for( const [ k, v ] of c.metrics ?? [] ) s.metrics.set( k, v )
+}
+
+/** A mind fragment: the real repertoire + the real learning engine. */
+function mind(){
+  const repertoire = new SchemaRepertoire()
+  const engine     = new ReafferenceEngine( repertoire )
+  const state      = freshState()
+  let   seq        = 0
+
+  /** Deliver a verdict as the world's answer to an attempt, and let the mind learn. */
+  const receive = async ( v: Verdict, tick: number ): Promise<StateCommands | undefined> => {
+    const id = `outcome-${ ++seq }`
+    state.entities.set( id, {
+      id, type: 'agency.outcome', createdAt: 0, updatedAt: 0,
+      metadata: {
+        schema: SCHEMA, intentId: `intent-${ seq }`, success: false,
+        refused: true, finality: v.finality,
+      },
+    } as SimulationEntity )
+    const out = await engine.react( 0, tick, frozen( state ), CTX )
+    apply( state, out.commands )
+    return out.commands
+  }
+
+  /** Let the mind ENACT successfully, so there is real competence to protect. */
+  const succeed = async ( tick: number ): Promise<void> => {
+    const id = `outcome-${ ++seq }`
+    state.entities.set( id, {
+      id, type: 'agency.outcome', createdAt: 0, updatedAt: 0,
+      metadata: {
+        schema: SCHEMA, intentId: `intent-${ seq }`, success: true,
+        outcomeQuality: 0.9, predictedReward: 0.5,
+      },
+    } as SimulationEntity )
+    apply( state, ( await engine.react( 0, tick, frozen( state ), CTX ) ).commands )
+  }
+
+  return { repertoire, engine, state, receive, succeed }
+}
+
+/** How strongly the mind would reach for the ability right now. */
+function reach( repertoire: SchemaRepertoire ): number {
+  const availability = repertoire.availabilityOf( SCHEMA )
+  const affordance: Affordance = {
+    id: 'a-1', schema: SCHEMA, source: 'external', parameters: {},
+    expectedValence: 0, expectedReward: 0.8, cost: 0.1, habitStrength: 0,
+    available: true, tags: [], tick: 1,
+    ...( availability < 1 ? { availability } : {} ),
+  }
+  return scoreAffordance( affordance, {
+    goalTargets: new Set<string>(), maxGoalPriority: 0,
+    drives: { energy: 0, sleep: 0, stress: 0, social: 0 }, threat: 0, inhibition: 0,
+  }, DEFAULT_WEIGHTS )
+}
+
+/** A stem with a real state manager, for the dispatch/hold/resolve scenarios. */
+function stem( intentId: string ){
+  const entities = new Map<string, SimulationEntity>()
+  entities.set( intentId, {
+    id: intentId, type: 'agency.intent', createdAt: 0, updatedAt: 0,
+    metadata: { schema: SCHEMA, status: 'awaiting', predictedReward: 0.5, predictedValence: 0 },
+  } as SimulationEntity )
+
+  const instance = {
+    config: { id: WILL_ID }, tickCount: 10,
+    pendingEffectorInvocations: [] as effectorInvocation[],
+    simulation: { stateManager: {
+      snapshot:  () => ({ entities }),
+      setEntity: ( e: { id: string } ) => entities.set( e.id, e as SimulationEntity ),
+      setMetric: () => {},
+    } },
+    cognition: { outboxWriter: { enqueue: () => {} } },
+  }
+  return { instance: instance as unknown as WillInstance, raw: instance, entities }
+}
+
+const fixed = ( v: Verdict ): PolicyArbiter => ({ name: 'pack', evaluate: () => v })
+const payload = ( intentId: string ) => ({ intentId, schema: SCHEMA, parameters: {}, tick: 9 })
+
+afterEach( () => { clearVerdictRecorder( WILL_ID ); clearVerdictSource( WILL_ID ) } )
+
+// ── the pack ─────────────────────────────────────────────────────────────────
+
+const byId = ( id: string ): Scenario => {
+  const s = SCENARIOS.find( x => x.id === id )
+  if( !s ) throw new Error(`no scenario ${ id }`)
+  return s
+}
+/** Title each test with the scenario's own words, so failures read as pack failures. */
+const T = ( id: string ): string => `${ id } · ${ byId( id ).title }`
+
+describe('Denials That Teach — conformance pack (consumer side)', () => {
+
+  it( T('S1'), async () => {
+    const m = mind()
+    await m.succeed( 1 )                                    // real competence to protect
+    const skillBefore = { ...m.repertoire.getSkill( SCHEMA )! }
+    const reachBefore = reach( m.repertoire )
+
+    await m.receive( helmAdapter('class_forbidden'), 2 )
+
+    expect( reach( m.repertoire ) ).toBeLessThan( reachBefore )       // reaches for it less
+    expect( m.repertoire.getSkill( SCHEMA ) ).toEqual( skillBefore )  // knows it just as well
+  } )
+
+  it( T('S2'), async () => {
+    const m = mind()
+    await m.succeed( 1 )
+    const skillBefore = { ...m.repertoire.getSkill( SCHEMA )! }
+
+    await m.receive(
+      helmAdapter('instance_parameter', 'BOUND', { field: 'amount', requested: 500, allowed: 100 } ),
+      2,
+    )
+
+    expect( m.repertoire.getSkill( SCHEMA ) ).toEqual( skillBefore )  // competence untouched
+    expect( m.repertoire.availabilityOf( SCHEMA ) ).toBeGreaterThan( 0.8 )  // still readily reachable
+  } )
+
+  it( T('S3'), async () => {
+    const m = mind()
+    await m.succeed( 1 )
+    const skillBefore = { ...m.repertoire.getSkill( SCHEMA )! }
+    const reachBefore = reach( m.repertoire )
+
+    const cmds = await m.receive( helmAdapter('instance_context', 'TAINT'), 2 )
+
+    expect( reach( m.repertoire ) ).toBe( reachBefore )               // nothing moved
+    expect( m.repertoire.getSkill( SCHEMA ) ).toEqual( skillBefore )
+    expect( m.repertoire.availability().size ).toBe( 0 )              // nothing written at all
+    expect( cmds?.delete ?? [] ).toContain('intent-2')                // but the action IS released
+  } )
+
+  it( T('S4'), () => {
+    const { instance, raw, entities } = stem('intent-approve')
+    const c = new effectorController()
+    c.setArbiter( fixed( helmAdapter('ungranted', 'APPROVAL_REQUIRED') ) )
+
+    c.bufferInvocation( instance, payload('intent-approve') )
+    c.applyPolicyOutcomes( instance )
+    expect( raw.pendingEffectorInvocations ).toHaveLength( 0 )        // withheld while unresolved
+    expect( entities.get('intent-approve')!.metadata!['escalated'] ).toBe( true )
+
+    c.resolveEscalation( instance, 'intent-approve', true )
+    c.applyPolicyOutcomes( instance )
+
+    expect( raw.pendingEffectorInvocations ).toHaveLength( 1 )        // reached the world once
+    // The SAME action resumed — not a re-issue. Both correlation handles must
+    // still be the id the action was first proposed with.
+    expect( raw.pendingEffectorInvocations[0]!.id ).toBe('intent-approve')
+    expect( raw.pendingEffectorInvocations[0]!.decisionRecordId ).toBe('intent-approve')
+  } )
+
+  it( T('S5'), () => {
+    const { instance, raw, entities } = stem('intent-expire')
+    const c = new effectorController()
+    c.setArbiter( fixed( helmAdapter('ungranted') ) )
+
+    c.bufferInvocation( instance, payload('intent-expire') )
+    c.applyPolicyOutcomes( instance )
+
+    // Nobody answers. Advance past the documented hold window.
+    ;( instance as unknown as { tickCount: number } ).tickCount = 10 + 31
+    c.applyPolicyOutcomes( instance )
+
+    expect( raw.pendingEffectorInvocations ).toHaveLength( 0 )        // never reached the world
+    const outcome = [ ...entities.values() ].find( e => e.type === 'agency.outcome')
+    expect( outcome ).toBeDefined()                                   // resolved, not hanging
+    expect( outcome!.metadata ).toMatchObject({ refused: true })      // as a refusal
+    expect( entities.get('intent-expire')!.metadata!['escalated'] ).toBeUndefined()
+  } )
+
+  it( T('S6'), async () => {
+    const m = mind()
+    let tick = 1
+    for( let i = 0; i < 8; i++ ) await m.receive( helmAdapter('class_forbidden'), tick++ )
+
+    const suppressed = m.repertoire.availabilityOf( SCHEMA )
+    expect( suppressed ).toBeLessThan( 0.1 )     // strongly suppressed …
+    expect( suppressed ).toBeGreaterThan( 0 )    // … but never zeroed: re-probe stays possible
+
+    // The policy relaxes: denials simply stop. No restart, no manual reset.
+    let recovered = suppressed
+    for( let i = 0; i < 40; i++ ){
+      m.repertoire.decay( tick++ )
+      const now = m.repertoire.availabilityOf( SCHEMA )
+      expect( now ).toBeGreaterThanOrEqual( recovered )   // monotone, and gradual
+      recovered = now
+    }
+    expect( recovered ).toBeGreaterThan( suppressed )
+  } )
+
+  it( T('S7'), () => {
+    const tape: PolicyVerdictRecord[] = []
+    setVerdictRecorder( WILL_ID, { recordVerdict: r => tape.push( r ) } )
+
+    const live = stem('intent-replay')
+    const lc   = new effectorController()
+    lc.setArbiter( fixed( helmAdapter('class_forbidden', 'NO') ) )
+    lc.bufferInvocation( live.instance, payload('intent-replay') )
+    lc.applyPolicyOutcomes( live.instance )
+    const liveDispatched = live.raw.pendingEffectorInvocations.length
+    expect( tape ).toHaveLength( 1 )
+
+    // Replay the SAME tape. The arbiter is a SPY, and we assert on the call
+    // count rather than only on the outcome — a throwing arbiter would be
+    // caught by the fail-closed path and produce a denial too, which is the
+    // same observable result as a correct replay. Counting the calls is the
+    // only assertion that actually distinguishes "re-fed" from "re-consulted".
+    clearVerdictRecorder( WILL_ID )
+    setVerdictSource( WILL_ID, new RecordedVerdictSource( tape ) )
+    let consulted = 0
+    const replay = stem('intent-replay')
+    const rc     = new effectorController()
+    rc.setArbiter({
+      name: 'must-not-run',
+      evaluate: () => { consulted++; return helmAdapter('instance_context') },
+    } )
+    rc.bufferInvocation( replay.instance, payload('intent-replay') )
+    rc.applyPolicyOutcomes( replay.instance )
+
+    expect( consulted ).toBe( 0 )                                                  // never consulted
+    expect( replay.raw.pendingEffectorInvocations.length ).toBe( liveDispatched )   // same decision
+    // …and the decision that was re-fed is the RECORDED one, not a fresh default.
+    const replayed = [ ...replay.entities.values() ].find( e => e.type === 'agency.outcome')
+    expect( replayed!.metadata ).toMatchObject({ refused: true, finality: 'class' })
+  } )
+
+  it( T('S8'), async () => {
+    const m = mind()
+    await m.succeed( 1 )
+    const out = await m.engine.react( 0, 2, frozen( m.state ), CTX )
+
+    expect( m.repertoire.availability().size ).toBe( 0 )                       // no policy state
+    const metricNames = ( out.commands?.metrics ?? [] ).map( x => x[0] )
+    expect( metricNames ).not.toContain('agency.refused.count')                // no policy telemetry
+    expect( metricNames ).not.toContain('agency.policy.revoked')
+
+    // And with no arbiter installed the seam does not intercept at all.
+    const { instance, raw } = stem('intent-quiet')
+    new effectorController().bufferInvocation( instance, payload('intent-quiet') )
+    expect( raw.pendingEffectorInvocations ).toHaveLength( 1 )
+  } )
+
+  it( T('S9'), async () => {
+    const tape: PolicyVerdictRecord[] = []
+    setVerdictRecorder( WILL_ID, { recordVerdict: r => tape.push( r ) } )
+
+    const { instance, raw, entities } = stem('intent-fault')
+    const c = new effectorController()
+    c.setArbiter({ name: 'unreachable', evaluate: () => { throw new Error('PDP unreachable') } } )
+
+    c.bufferInvocation( instance, payload('intent-fault') )
+    c.applyPolicyOutcomes( instance )
+
+    expect( raw.pendingEffectorInvocations ).toHaveLength( 0 )        // withheld — fail closed
+    expect( tape ).toHaveLength( 1 )                                  // and RECORDED, so replay agrees
+    expect( tape[0] ).toMatchObject({ decision: 'deny' })
+
+    // The outage must not read as incompetence: feed the resulting ack to a mind
+    // that is good at this, and confirm its competence survives untouched.
+    const outcome = [ ...entities.values() ].find( e => e.type === 'agency.outcome')!
+    const m = mind()
+    await m.succeed( 1 )
+    const skillBefore = { ...m.repertoire.getSkill( SCHEMA )! }
+
+    m.state.entities.set('fault-ack', {
+      id: 'fault-ack', type: 'agency.outcome', createdAt: 0, updatedAt: 0,
+      metadata: { ...outcome.metadata, schema: SCHEMA, intentId: 'intent-fault' },
+    } as SimulationEntity )
+    apply( m.state, ( await m.engine.react( 0, 2, frozen( m.state ), CTX ) ).commands )
+
+    expect( m.repertoire.getSkill( SCHEMA ) ).toEqual( skillBefore )  // competence untouched
+    expect( m.repertoire.availability().size ).toBe( 0 )              // and nothing else moved
+  } )
+} )
+
+// ── the pack is self-describing: every scenario must have a test ─────────────
+
+describe('pack integrity', () => {
+  it('runs every scenario declared in the manifest', () => {
+    const declared = SCENARIOS.map( s => s.id )
+    expect( declared ).toEqual([ 'S1', 'S2', 'S3', 'S4', 'S5', 'S6', 'S7', 'S8', 'S9' ])
+    expect( new Set( declared ).size ).toBe( declared.length )
+  } )
+
+  it('states honestly where the reference consumer stands', () => {
+    const { total, asserted, partial, pending } = packSummary()
+    expect( asserted + partial + pending ).toBe( total )
+    // Anything not fully asserted MUST say what is missing — a pack that quietly
+    // under-tests is worse than one that reports a gap.
+    for( const s of SCENARIOS )
+      if( s.status !== 'asserted') expect( s.note, `${ s.id } lacks a note` ).toBeTruthy()
+  } )
+} )

--- a/tests/conformance/emit.ts
+++ b/tests/conformance/emit.ts
@@ -1,0 +1,34 @@
+// ─────────────────────────────────────────────────────────────
+// tests/conformance/emit.ts — serialize the pack for upstream
+// ─────────────────────────────────────────────────────────────
+//
+//   bun tests/conformance/emit.ts            → prints the manifest
+//   bun tests/conformance/emit.ts out.json   → writes it
+//
+// The scenarios are the half we contribute to HELM's conformance pack, and
+// HELM's runner is Go — so they have to leave TypeScript. `scenarios.ts` is
+// kept free of Will imports precisely so this stays a one-liner.
+// ─────────────────────────────────────────────────────────────
+
+import { writeFileSync } from 'node:fs'
+import { SCENARIOS, packSummary } from './scenarios'
+
+const manifest = {
+  pack:     'denials-that-teach',
+  rfc:      'HELM × Will v0.1',
+  consumer: '@mindot/will',
+  // Reported, not hidden: a pack that quietly under-tests is worse than one
+  // that says where it stands.
+  summary:  packSummary(),
+  scenarios: SCENARIOS,
+}
+
+const json = JSON.stringify( manifest, null, 2 )
+const out  = process.argv[2]
+
+if( out ){
+  writeFileSync( out, json + '\n')
+  const { total, asserted, partial } = manifest.summary
+  console.log(`✓ ${ out } — ${ total } scenarios (${ asserted } asserted, ${ partial } partial)`)
+}
+else console.log( json )

--- a/tests/conformance/scenarios.ts
+++ b/tests/conformance/scenarios.ts
@@ -1,0 +1,196 @@
+// ─────────────────────────────────────────────────────────────
+// tests/conformance/scenarios.ts
+// ─────────────────────────────────────────────────────────────
+// "Denials That Teach" — the consumer-side conformance pack (HELM × Will).
+//
+// This file is the LANGUAGE-NEUTRAL half: nine scenarios describing what any
+// consumer of a HELM denial receipt must observably do. It is deliberately free
+// of Will types and Will imports so it can be serialized (`bun tests/conformance/
+// emit.ts`) and handed to a pack whose runner is Go, Python, or anything else.
+// `denials-that-teach.test.ts` is Will's implementation of it.
+//
+// THE ASSERTIONS ARE STATE DELTAS, NEVER TYPE NAMES. A consumer conforms by
+// behaving correctly, not by spelling its internals the way HELM does — Will's
+// own enum is `class | parameter | context` and it maps HELM's four wire values
+// at the adapter. Any other consumer should be free to do the same.
+//
+// `status` is honest about where the reference consumer actually stands, so the
+// pack reports reality rather than intent:
+//   'asserted' — fully exercised by the runner below.
+//   'partial'  — the implemented half is exercised; the rest names what is missing.
+//   'pending'  — not yet implementable here.
+// ─────────────────────────────────────────────────────────────
+
+export type ScenarioStatus = 'asserted' | 'partial' | 'pending'
+
+export interface Scenario {
+  /** Stable pack id. */
+  id:      string
+  title:   string
+  /** The wire value(s) under test, in HELM's spelling. 'n/a' for the two
+   *  scenarios that are about the ABSENCE of a verdict (S8) or its replay (S7). */
+  wire:    string
+  /** What this scenario exists to prove — the normative one-liner. */
+  proves:  string
+  /** Observable deltas a conforming consumer must exhibit. Prose on purpose:
+   *  these must be checkable against any implementation, not just this one. */
+  asserts: readonly string[]
+  status:  ScenarioStatus
+  /** Required when status !== 'asserted'. What is missing and why. */
+  note?:   string
+}
+
+export const SCENARIOS: readonly Scenario[] = [
+  {
+    id:    'S1',
+    title: 'A class denial on a well-practiced ability',
+    wire:  'class_forbidden',
+    proves:
+      'A hard denial suppresses REACHING for an ability without touching how ' +
+      'well the consumer knows how to do it. Forbidden is not unskilled.',
+    asserts: [
+      'the ability becomes markedly less likely to be selected',
+      'learned competence for that ability is completely unchanged',
+      'any learned parameter envelope for the ability is discarded',
+    ],
+    status: 'partial',
+    note:
+      'The first two are asserted. Envelope erasure is not: Will has no envelope ' +
+      'layer yet (ENVELOPE_NARROWING is designed, not built), so there is nothing ' +
+      'to erase. Re-check this scenario when that lands.',
+  },
+  {
+    id:    'S2',
+    title: 'A parameter denial carrying a counterfactual',
+    wire:  'instance_parameter',
+    proves:
+      'A bound denial teaches HOW MUCH of an ability may be used, rather than ' +
+      'denting the ability as a whole.',
+    asserts: [
+      'competence is unchanged',
+      'the ability remains readily selectable — this is not a suppression',
+      'a subsequent attempt respects the bound the counterfactual named',
+    ],
+    status: 'partial',
+    note:
+      'The first two are asserted. Bound-respecting enaction requires the envelope ' +
+      'layer (ENVELOPE_NARROWING P1), which is itself blocked upstream: a scalar ' +
+      '`allowed` cannot be folded until the receipt says whether it is a ceiling ' +
+      'or a floor. This is the open ask in our reply.',
+  },
+  {
+    id:    'S3',
+    title: 'A context denial',
+    wire:  'instance_context',
+    proves:
+      'A refusal that was not about the action teaches nothing about the action. ' +
+      'This is the scenario most consumers will get wrong by denting anyway.',
+    asserts: [
+      'selection likelihood is unchanged',
+      'competence is unchanged',
+      'no learned state of any kind is written for the ability',
+      'the pending action is still released — teaching nothing must not mean hanging',
+    ],
+    status: 'asserted',
+  },
+  {
+    id:    'S4',
+    title: 'An ungranted denial that a human then approves',
+    wire:  'ungranted',
+    proves:
+      'An approval resumes the ORIGINAL action rather than re-issuing it. The ' +
+      'distinction matters for anything non-idempotent.',
+    asserts: [
+      'the action does not reach the world while unresolved',
+      'on approval the action reaches the world exactly once',
+      'it carries the same correlation id it was first proposed with',
+    ],
+    status: 'asserted',
+  },
+  {
+    id:    'S5',
+    title: 'An ungranted denial nobody answers',
+    wire:  'ungranted',
+    proves:
+      'An unanswered ask resolves deterministically instead of hanging forever ' +
+      'or silently proceeding.',
+    asserts: [
+      'the action never reaches the world',
+      'the hold resolves on its own within a bounded, documented time',
+      'it resolves as a refusal, not as a failure of the ability',
+    ],
+    status: 'asserted',
+  },
+  {
+    id:    'S6',
+    title: 'A policy that relaxes mid-run',
+    wire:  'class_forbidden, then allow',
+    proves:
+      'THE SCENARIO THAT KEEPS THIS FROM DEGENERATING. A consumer that zeroes a ' +
+      'forbidden ability permanently can never discover the policy changed, and ' +
+      'is a static blocklist wearing a learning loop.',
+    asserts: [
+      'after repeated denials the ability is strongly suppressed but never fully removed',
+      'the ability recovers once denials stop, without a restart or manual reset',
+      'recovery is gradual, not instantaneous',
+    ],
+    status: 'asserted',
+  },
+  {
+    id:    'S7',
+    title: 'Replay against a recorded verdict tape',
+    wire:  'n/a — recorded verdicts',
+    proves:
+      'A decision is an input to be recorded, not recomputed. A replay that ' +
+      're-consults the PDP is not a replay, and cannot be audited as one.',
+    asserts: [
+      'replaying a recorded run reproduces the same decisions',
+      'the policy decision point is never consulted during replay',
+    ],
+    status: 'asserted',
+  },
+  {
+    id:    'S8',
+    title: 'No policy configured',
+    wire:  'n/a — no PDP',
+    proves:
+      'The boundary costs nothing when absent. A consumer that behaves ' +
+      'differently with policy disabled cannot claim the boundary is auditable.',
+    asserts: [
+      'no policy-derived state is written',
+      'no policy-derived telemetry is emitted',
+      'behaviour is indistinguishable from a build without the seam',
+    ],
+    status: 'asserted',
+  },
+  {
+    id:    'S9',
+    title: 'The policy decision point is unreachable',
+    wire:  'n/a — fault',
+    proves:
+      'An outage is not a fact about the ability. Failing closed is necessary ' +
+      'but not sufficient: HOW the consumer records the withholding matters.',
+    asserts: [
+      'the action is withheld — fail closed',
+      'competence is not touched; an outage must not read as incompetence',
+      'the withholding is recorded, so a replay reproduces it rather than proceeding',
+    ],
+    status: 'asserted',
+    note:
+      'Will FAILED this scenario until 2026-07-28. The effect was withheld ' +
+      'correctly, but the held action decayed into an ordinary failure, which ' +
+      'landed on competence — and the fault went unrecorded, so a replay would ' +
+      'have dispatched an effect the live run withheld. Both fixed in P5.',
+  },
+] as const
+
+/** Pack-level summary, for the manifest header and the runner's final report. */
+export function packSummary(): { total: number; asserted: number; partial: number; pending: number } {
+  const count = ( s: ScenarioStatus ): number => SCENARIOS.filter( x => x.status === s ).length
+  return {
+    total:    SCENARIOS.length,
+    asserted: count('asserted'),
+    partial:  count('partial'),
+    pending:  count('pending'),
+  }
+}


### PR DESCRIPTION
The consumer-side half of the joint RFC's conformance packs, as runnable fixtures. Unblocked by design — these assert **our** behaviour given a verdict, so they need nothing from HELM and can ship alongside the reply.

## Two files on purpose

- **`scenarios.ts`** — language-neutral scenario definitions, free of Will imports and Will types, so `emit.ts` can serialize them for a pack whose runner is Go. **This is the half we contribute upstream.**
- **`denials-that-teach.test.ts`** — Will's implementation of it.

Every assertion is an **observable state delta, never a type name**: availability, competence, what reached the world, what was recorded. A consumer conforms by *behaving* correctly, whatever it calls things internally — which is precisely what lets Will keep `class|parameter|context` and still be certifiable.

Verdicts are written in HELM's **wire** spelling and pushed through a four-arm `helmAdapter()`, so the pack exercises the translation too, not just the fates behind it. That adapter is the P6 mapping in miniature.

## Status is reported, not hidden

**7 asserted, 2 partial.** S1 and S2 both depend on the envelope layer (ENVELOPE_NARROWING) — designed, not built, and its fold is itself blocked on the counterfactual-direction question we asked upstream. Each partial scenario carries a note saying exactly what's missing, and a pack-integrity test **enforces** that a non-asserted scenario can't ship without one.

A pack that quietly under-tests is worse than one that reports a gap — especially when we're the reference consumer.

## Mutation-tested, not assumed

| mutation | caught by |
| :--- | :--- |
| `context` dents availability (the bug P5 fixed) | S3, S9 |
| replay ignores the tape and re-consults the PDP | S7 |

**That second one caught a vacuous test of my own making.** S7 originally used an arbiter that *threw* if consulted during replay — but P5's fail-closed path now catches that throw and produces a denial, which is the same observable result as a correct replay. It passed either way. It now spies on the call count (the only assertion that distinguishes *re-fed* from *re-consulted*) and additionally checks the re-fed verdict is the **recorded** one rather than a fresh default.

## Emitting for upstream

```bash
bun tests/conformance/emit.ts out.json
```

## Verification

Suite **1179 passed / 2 skipped (175 files)** · typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)