### PR TITLE
refactor(config): model rides with the transport, and every provider is first class

### DIFF
--- a/src/cognition/config.mirror.entities.ts
+++ b/src/cognition/config.mirror.entities.ts
@@ -34,7 +34,7 @@ export function buildEngineConfigEntities( config: WillConfig, executiveInterval
       engine: 'system',
       params: {
         anatomy:        config.anatomy ?? 'mind',
-        model:          config.model ?? '',
+        model:          config.llm?.model ?? '',
         tickIntervalMs: config.tickIntervalMs ?? 1000
       }
     },

--- a/src/sdk/will.ts
+++ b/src/sdk/will.ts
@@ -29,6 +29,7 @@
 
 import { WillStem } from '#stem/index'
 import type { WillConfig, WillIdentity, Anatomy, InitialGoal, WillModelConfig, WillLLMConfig } from '#stem/mind'
+import type { LLMProvider } from '#llm/index'
 import type { PMASnapshot } from '#pma/index'
 import type { effectorInvocation } from '#types'
 import type { EffectorDeclaration, SchemaPrecondition } from '#agency/types'
@@ -165,20 +166,33 @@ export interface CreateWillOptions {
   anatomy?: Anatomy
   /** Concrete LLM model id, or a per-role map ({ executive, summarizer?,
    *  deliberation?, embedding? } — unset thinking roles fall back to executive).
-   *  Unset → env / provider default. */
+   *  Unset → env / provider default.
+   *  @deprecated Pass `llmConfig: { model }` instead — model and transport are
+   *  one concern. Still honoured; an explicit `llmConfig.model` wins. */
   model?: string | WillModelConfig
-  /** Per-Will LLM transport overrides (provider, BYO apiKey, baseUrl, caps).
+  /** Per-Will LLM config: provider, model(s), BYO apiKey, baseUrl, caps.
    *  Unset fields fall back to WILL_LLM_* envs. apiKey stays in memory only.
-   *  (Named llmConfig because `llm` is the mock/anthropic MODE switch.) */
+   *  (Named llmConfig because `llm` is the provider MODE switch.) */
   llmConfig?: WillLLMConfig
    /**
-   * LLM mode. 'mock' (default when no key is present) runs a deterministic
-   * canned executive — zero keys, zero cost. 'anthropic' calls Claude (needs
-   * ANTHROPIC_API_KEY / WILL_LLM_* env); 'glm' calls Z.ai's GLM over its
-   * Anthropic-compatible endpoint (needs ZAI_API_KEY / WILL_LLM_*). Omit to
-   * auto-detect from whichever key is set.
+   * LLM mode — which provider the executive speaks to.
+   *
+   * 'mock' (the default when no key is present) runs a deterministic canned
+   * executive: zero keys, zero cost. Every other value names a provider and
+   * needs its key, either the provider's own env below or the
+   * provider-agnostic WILL_LLM_API_KEY:
+   *
+   *   anthropic  ANTHROPIC_API_KEY   Claude, native Messages wire
+   *   glm        ZAI_API_KEY         Z.ai GLM, Anthropic-compatible wire
+   *   deepseek   DEEPSEEK_API_KEY    OpenAI wire
+   *   openai     OPENAI_API_KEY      OpenAI wire — also any OpenAI-compatible
+   *                                  server (Ollama, vLLM, Together, OpenRouter,
+   *                                  Kimi, Qwen…) via `llmConfig.baseUrl`
+   *   google     GOOGLE_API_KEY | GEMINI_API_KEY
+   *
+   * Omit to auto-detect from whichever key is set.
    */
-  llm?: 'mock' | 'anthropic' | 'glm'
+  llm?: 'mock' | LLMProvider
   /**
    * Abilities the Will can choose to enact. `name → handler`, or
    * `name → { handler, description?, cost?, valence?, preconditions? }` to seed
@@ -212,6 +226,25 @@ interface UtteranceWaiter {
 const AFFECT_EPSILON = 0.02
 
 // ── The facade ────────────────────────────────────────────────
+
+
+/**
+ * Which provider to talk to when the caller did not say.
+ *
+ * Checks the provider-agnostic key first (it means "I configured this
+ * deliberately"), then each provider's conventional env. The order among
+ * providers is detection precedence when several keys happen to be present —
+ * it is not a ranking, and no provider here is more supported than another.
+ */
+function detectProvider(): 'mock' | LLMProvider {
+  if( process.env.WILL_LLM_API_KEY ) return ( process.env.WILL_LLM_PROVIDER as LLMProvider ) ?? 'anthropic'
+  if( process.env.ANTHROPIC_API_KEY ) return 'anthropic'
+  if( process.env.ZAI_API_KEY ) return 'glm'
+  if( process.env.DEEPSEEK_API_KEY ) return 'deepseek'
+  if( process.env.OPENAI_API_KEY ) return 'openai'
+  if( process.env.GOOGLE_API_KEY || process.env.GEMINI_API_KEY ) return 'google'
+  return 'mock'
+}
 
 export class Will {
   /** The underlying WillStem — drop here for the full contract. */
@@ -462,13 +495,22 @@ export class Will {
 
   private _buildConfig( id: string, opts: CreateWillOptions ): WillConfig {
     // Auto-detect from whichever provider key is present; explicit `llm` wins.
-    const mode = opts.llm
-      ?? ( process.env.ANTHROPIC_API_KEY ? 'anthropic' : process.env.ZAI_API_KEY ? 'glm' : 'mock')
+    // Order is detection precedence when several keys are set, not a
+    // recommendation — every provider here is a first-class target.
+    const mode = opts.llm ?? detectProvider()
     const useMock = mode === 'mock'
-    // `llm: 'glm'` selects the provider; an explicit llmConfig still overrides it.
-    const llmConfig = mode === 'glm'
-      ? { provider: 'glm' as const, ...opts.llmConfig }
-      : opts.llmConfig
+    // `llm` selects the provider; an explicit llmConfig.provider still wins.
+    // Model rides with the transport: `llmConfig.model` is canonical, the
+    // top-level `opts.model` is the deprecated spelling of the same thing.
+    const llmConfig: WillLLMConfig | undefined = useMock && !opts.llmConfig && opts.model === undefined
+      ? undefined
+      : {
+          ...( mode !== 'mock' ? { provider: mode } : {} ),
+          ...opts.llmConfig,
+          ...( opts.llmConfig?.model !== undefined ? { model: opts.llmConfig.model }
+             : opts.model        !== undefined ? { model: opts.model }
+             : {} ),
+        }
     return {
       id, name: opts.name,
       identity: {
@@ -478,7 +520,6 @@ export class Will {
         style:  opts.identity.style ?? '',
       },
       anatomy: opts.anatomy ?? 'mind',
-      model:   opts.model,
       llm:     llmConfig,
       testMode:   useMock,
       persistentMemory: opts.persist ?? false,

--- a/src/stem/index.ts
+++ b/src/stem/index.ts
@@ -95,7 +95,7 @@ export interface WillSummary {
   createdAt:  Date
   lastTickAt: Date | null
   anatomy:    WillConfig['anatomy']
-  model:      WillConfig['model']
+  model:      NonNullable<WillConfig['llm']>['model']
 }
 
 // Re-export WillConfig so the API layer only imports from manager
@@ -289,7 +289,7 @@ export class WillStem {
       willId:     config.id,
       willName:   config.name,
       anatomy:    config.anatomy ?? 'mind',
-      model:      config.model ?? null,
+      model:      config.llm?.model ?? null,
       startedAt:  new Date().toISOString(),
     })
 
@@ -942,7 +942,7 @@ export class WillStem {
       createdAt:  inst.createdAt,
       lastTickAt: inst.lastTickAt,
       anatomy:    inst.config.anatomy ?? 'mind',
-      model:      inst.config.model,
+      model:      inst.config.llm?.model,
     }))
   }
 

--- a/src/stem/mind.ts
+++ b/src/stem/mind.ts
@@ -143,6 +143,15 @@ export interface WillLLMConfig {
   baseUrl?:         string
   maxOutputTokens?: number
   timeoutMs?:       number
+  /**
+   * Concrete LLM model id(s) for this Will — a single id for every role, or a
+   * per-role map. An explicit WILL_LLM_MODEL env pins the thinking roles
+   * (operator single-model deployments); unset roles fall back to `executive`,
+   * then the LLMDirector's built-in default. Product-level labels (pricing
+   * tiers, model families) live host-side and resolve to concrete ids BEFORE
+   * reaching the engine.
+   */
+  model?: string | WillModelConfig
 }
 
 /** Executive-side resolved roles (embedding is threaded separately). */
@@ -222,16 +231,6 @@ export interface WillConfig {
 
   /** Anatomy — 'mind' (default) or the no-LLM 'reflex' shell. */
   anatomy?: Anatomy
-
-  /**
-   * Concrete LLM model id(s) for this Will — a single id for every role, or a
-   * per-role map. An explicit WILL_LLM_MODEL env pins the thinking roles
-   * (operator single-model deployments); unset roles fall back to `executive`,
-   * then the LLMDirector's built-in default. Product-level labels (pricing
-   * tiers, model families) live host-side and resolve to concrete ids BEFORE
-   * reaching the engine.
-   */
-  model?: string | WillModelConfig
 
   /**
    * Per-Will LLM transport overrides (provider, BYO apiKey, baseUrl, output
@@ -708,7 +707,7 @@ function _constructCognition(
 
   // Per-Will, per-ROLE models (env WILL_LLM_MODEL pins all thinking roles —
   // operator single-model deployments). No tier vocabulary inside the engine.
-  const modelRoles = resolveModelRoles( config.model )
+  const modelRoles = resolveModelRoles( config.llm?.model )
 
   const { embedder, vectorMemory } = _resolveVectorMemory( willId, randomSeed, config.vectorMemoryAdapter, config.disableVectorMemory, tokenTracker, config.testMode, modelRoles.embedding ?? undefined )
   const episodicConsolidator = new EpisodicConsolidator( vectorMemory ? { vectorMemory, ...(embedder ? { embedder } : {}) } : {} )

--- a/tests/unit/assembly.order.test.ts
+++ b/tests/unit/assembly.order.test.ts
@@ -156,19 +156,19 @@ describe('mind assembly — order + wiring as reviewed artifacts', () => {
     } )
   }
 
-  it('threads config.model to the executive as a concrete id (env pin wins)', () => {
+  it('threads config.llm.model to the executive as a concrete id (env pin wins)', () => {
     const saved = process.env['WILL_LLM_MODEL']
     delete process.env['WILL_LLM_MODEL']
     try {
       const { cognition } = assembleMind('assembly-model', {
-        ...makeConfig('mind'), id: 'assembly-model', model: 'test-model-id',
+        ...makeConfig('mind'), id: 'assembly-model', llm: { model: 'test-model-id' },
       } )
       expect( cognition.executiveEngine.modelId ).toBe('test-model-id')
 
       // Per-role map: summarizer diverges, deliberation falls back to executive.
       const { cognition: c3 } = assembleMind('assembly-model-3', {
         ...makeConfig('mind'), id: 'assembly-model-3',
-        model: { executive: 'big-model', summarizer: 'small-model' },
+        llm: { model: { executive: 'big-model', summarizer: 'small-model' } },
       } )
       expect( c3.executiveEngine.models ).toEqual( {
         executive: 'big-model', summarizer: 'small-model', deliberation: 'big-model', conversation: 'big-model',
@@ -176,7 +176,7 @@ describe('mind assembly — order + wiring as reviewed artifacts', () => {
 
       process.env['WILL_LLM_MODEL'] = 'operator-pin'
       const { cognition: c2 } = assembleMind('assembly-model-2', {
-        ...makeConfig('mind'), id: 'assembly-model-2', model: 'test-model-id',
+        ...makeConfig('mind'), id: 'assembly-model-2', llm: { model: 'test-model-id' },
       } )
       expect( c2.executiveEngine.modelId ).toBe('operator-pin')
     } finally {


### PR DESCRIPTION
Two related cleanups: consolidating the LLM config, and removing the assumption that Anthropic is the default shape of the world.

## `model` moves into `WillLLMConfig`

`WillConfig` carried `model` and `llm` as two top-level fields describing one decision — a Will could say `model: 'glm-5.2'` while `llm.provider` said `anthropic`, and nothing objected.

It matters beyond tidiness: `llm` is also where the per-provider map and the routing table will live. Leaving `model` at the top level would have put model in one place, credentials in a second, and routing in a third — three fields describing where a single call goes.

Callers updated: config mirror, session-start log, the `WillInstance` view, the SDK builder, and the assembly test. **The SDK keeps `opts.model` working** as a deprecated alias folding into `llmConfig.model` (explicit `llmConfig.model` wins), so embedders aren't broken.

## Every provider is now reachable

| Issue | Before | After |
|---|---|---|
| SDK `llm` mode | `'mock' \| 'anthropic' \| 'glm'` — **2 of 5 providers unreachable from the SDK** | `'mock' \| LLMProvider` |
| Auto-detection | `ANTHROPIC_API_KEY` → `ZAI_API_KEY` → give up. A dev with only `DEEPSEEK_API_KEY` or `OPENAI_API_KEY` **silently got the mock executive** | Provider-agnostic `WILL_LLM_API_KEY` first, then each provider's conventional env |
| Docs | "`llm` is the mock/anthropic MODE switch" | Every provider named with its env + wire, noting `openai` + `baseUrl` reaches any OpenAI-compatible server (Ollama, vLLM, Together, OpenRouter, Kimi, Qwen…) |

Detection order is documented as **precedence when several keys are set — not a ranking**.

## Knowingly left for the pricing pass

Called out in the commit so they don't get lost:

- `defaultModelFor()` returns a Claude id for every provider except `glm`
- the apiKey fallback chain still ends at `ANTHROPIC_API_KEY`
- `__default__` in `MODEL_PRICING` is Sonnet's `$3/$15`, so an **unpriced model is silently billed as Claude** — which is currently ~20 of the ~23 models the cost model names

## Verification

Typecheck clean. Suite **1200 pass · 2 skip · 0 fail**.

Breaking for direct `WillConfig` consumers (`config.model` → `config.llm.model`); SDK users unaffected. Needs a CHANGELOG note before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)