### PR TITLE
release: 0.8.0 — the mind thinks at more than one depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased — the mind thinks at more than one depth
+## 0.8.0 — 2026-07-29 · the mind thinks at more than one depth
 
 A mind does several kinds of work, and they were all being done by one model.
 Summarising the last hour is not the same act as deciding what to do next, and a
@@ -61,6 +61,35 @@ reconfigured. Host-supplied prices have no determinism surface at all: they can
 change between a recording and its replay and the run still holds. A router that
 throws, or names a provider with no credential, degrades to the default model —
 a routing mistake never kills a running mind.
+
+### Also in this release
+
+Two epochs' worth of work sat on main. The story above is the routing one; the
+**policy-reafference tail** rides along, and is listed here so release
+archaeology does not have to reconstruct it from the log:
+
+- **The finality taxonomy splits three ways** (#87). A refusal's `'instance'`
+  fate was really two things wanting opposite responses, so the enum became
+  `'class' | 'parameter' | 'context'` — `parameter` dents availability lightly,
+  `context` touches nothing at all, and an arbiter fault now refuses as
+  `context` instead of decaying into a competence-scarring timeout.
+- **"Denials That Teach" — the conformance pack, S1–S9** (#88), and the
+  vocabulary reconciliation behind it (#83, #86): these are OUR names for the
+  distinctions the joint RFC with the HELM builders established, never their
+  wire spellings.
+- **The counterfactual survives the ack** (#89). The bound a denial reports
+  reached the verdict tape but was dropped before the outcome the mind actually
+  learns from. Tape and outcome now agree.
+
+**None of it is reachable from this package.** `PolicyArbiter`, `Verdict` and
+`finality` are not exported, and nothing reads the new fields yet — that is the
+next phase, and it stays blocked upstream on an open question in the joint RFC
+(a scalar `allowed` cannot be told from a ceiling or a floor). So this release
+publishes no policy contract, and the RFC's conclusion cannot contradict one.
+The policy epoch gets its own release when it closes.
+
+Also: the release ritual itself (#81, #82, #90) — `RELEASE.md` now records
+**when** to cut, not just how.
 
 ## 0.7.0 — 2026-07-22 · the mind learns may from can
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mindot/will",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "author": "Fabrice <fabrice8@github.com>",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Two files, per `RELEASE.md` step 4 — `CHANGELOG.md` and `package.json`.

## The epoch

A mind does several kinds of work, and they were all being done by one model. Summarising the last hour is not the same act as deciding what to do next, and a Will was paying — in latency, in money, in capability left on the table — as though they were.

Now its deliberation can run on something deep, its rolling summary on something cheap, its voice on something fast. **What decides is the character of the moment, not a plan or a price.**

- **The mind reports `demand`** — a cognitive measure of how consequential this instant is, not a commercial one. Inert with respect to cognition: nothing reads it back, so routing can never become a hidden input to the mind.
- **One question, one answer.** The role map decided at facet *spawn*; the router decided per *call*. A facet held its spawn-time model for life even as its work changed. The map now compiles into rules.
- **Provider, model and key are named, never guessed** — including the key fallback that would hand one vendor's secret to another.
- **Twelve providers first-class**, each called by its own name, because the transport branches on *wire*, not vendor.
- **Prices and dollars belong to the host.** The engine ships no price table; an unpriced model reports cost 0 with `priced: false` rather than a confident wrong number.

**Throughout:** a Will with no router and one model is byte-identical to one built before any of this existed. Replay never consults a router, and host prices have no determinism surface at all.

## Also in this release

The **policy-reafference tail** (#83, #86, #87, #88, #89) — the finality taxonomy, the "Denials That Teach" conformance pack, the counterfactual surviving onto the outcome.

**None of it is reachable from this package.** `PolicyArbiter`, `Verdict` and `finality` are not exported, nothing reads the new fields yet, and the next phase stays blocked upstream on an open question in the joint RFC with the HELM builders (a scalar `allowed` cannot be told from a ceiling or a floor).

So this release **publishes no policy contract, and the RFC's conclusion cannot contradict one.** That epoch gets its own release when it closes — which is what `RELEASE.md`'s own worked example predicted: *"the whole tail will ride the release that follows, whichever of those lands first."*

## Pre-flight

- **1255 pass · 2 skip · 0 fail** under both runners
- **replay-equivalence green** — determinism is a release gate, not a nice-to-have
- `tsc --noEmit` clean · `dist/` committed and current
- The picture: `docs/graphs/model-routing.svg` ([#99](https://github.com/mindot-ai/will/pull/99))

## After merge

Publishing the GitHub Release `v0.8.0` is **the human gate** — that fan-out is yours to trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)