### PR TITLE
feat(agency): having thought about it leaves a trace

### DIFF
--- a/src/cognition/agency/engines/action.selector.ts
+++ b/src/cognition/agency/engines/action.selector.ts
@@ -37,6 +37,7 @@ import {
 } from '#agency/selection.scoring'
 import { readEffectiveParams, readPersonaPrior } from '#cognition/persona.prior'
 import { RUPTURE_REVOKE_GATE, revocationEntity } from '#agency/revocation'
+import { liveSettlements, settlementId } from '#agency/settlement'
 import { liveConsequences, matchConsequenceText } from '#agency/consequence'
 import { asFinality } from '#stem/policy/arbiter'
 
@@ -285,8 +286,23 @@ export class ActionSelector implements CognitiveEngine {
       catch( err ){ logger.warn(`[selector] rupture publish failed: ${ err instanceof Error ? err.message : String( err ) }`) }
     }
 
+    // A verdict is held only while the situation that produced it stands. A hard
+    // rupture means the world just contradicted the premises the mind decided
+    // on, so every standing settlement lapses and those questions are genuinely
+    // open again — the same reasoning that revokes a commitment still being
+    // weighed, applied to the ones already settled.
+    //
+    // Deliberately NOT conditioned on something being deliberated right now: the
+    // entire point of a settlement is that it outlives the intent that formed
+    // it, so it has to be able to lapse without one.
+    const settlementDrops = rupture >= RUPTURE_REVOKE_GATE
+      ? liveSettlements( state.entities, tick ).map( s => settlementId( s.schema, s.targetEntityId ) )
+      : []
+    const dropSettled = settlementDrops.length > 0 ? { delete: settlementDrops } : {}
+
     const busy = ( n: number ): EngineResult => ({
       commands: {
+        ...dropSettled,
         metrics: [
           [ 'agency.field.eligible', n ],
           [ 'agency.selection.busy', 1 ],
@@ -323,6 +339,7 @@ export class ActionSelector implements CognitiveEngine {
       return {
         commands: {
           set: [ revocationEntity( deliberating.id, deliberating.schema, revRupture, tick ) ],
+          ...dropSettled,
           metrics: [
             [ 'agency.field.eligible', eligible.length ],
             [ 'agency.selection.busy', 1 ],
@@ -340,6 +357,7 @@ export class ActionSelector implements CognitiveEngine {
     if( eligible.length === 0 )
       return {
         commands: {
+          ...dropSettled,
           metrics: [
             [ 'agency.field.eligible', 0 ],
             [ 'agency.selection.busy',( awaiting || composite ) ? 1 : 0 ],
@@ -628,7 +646,9 @@ export class ActionSelector implements CognitiveEngine {
       set: compositeTombstone
         ? [ intent, revocationEntity( compositeTombstone, compositeFrom ?? '', rupture, tick ) ]
         : [ intent ],
-      ...( preemptDelete ? { delete: [ preemptDelete ] } : {} ),
+      ...( preemptDelete || settlementDrops.length > 0
+        ? { delete: [ ...( preemptDelete ? [ preemptDelete ] : [] ), ...settlementDrops ] }
+        : {} ),
       metrics: [
         [ 'agency.field.eligible',       eligible.length ],
         [ 'agency.selection.busy',       0 ],
@@ -804,6 +824,10 @@ function buildBias( state: ReadonlySimulationState ): BiasContext {
  *     P5 and the `spokenAt` durability fix both landed on a field nothing read.
  *   • `availability` — POLICY_REAFFERENCE P2 damps a refused ability so it competes
  *     weakly instead of vanishing. `a.availability ?? 1` read the fallback forever.
+ *   • `settled` — a verdict System 2 already reached. Same weight class as
+ *     `justEnacted` and the same failure if dropped: the mind re-deliberates a
+ *     question it has answered, forever. Added WITH its decoder rather than
+ *     after someone notices the mechanism is dark.
  *   • `description` — the schema's MEANING. The selector snapshots it onto
  *     `metadata.candidates` and the DeliberationEngine renders it as `— <what>`,
  *     so the candidate list the mind reasons over listed acts with no meanings.
@@ -831,6 +855,7 @@ export function readAffordance( id: string, m: ReadonlyMap<string, unknown> | Re
     willBias:        typeof meta['willBias'] === 'number' ? ( meta['willBias'] as number ) : undefined,
     socialPrior:     typeof meta['socialPrior'] === 'number' ? ( meta['socialPrior'] as number ) : undefined,
     justEnacted:     typeof meta['justEnacted'] === 'number' ? ( meta['justEnacted'] as number ) : undefined,
+    settled:         typeof meta['settled'] === 'number' ? ( meta['settled'] as number ) : undefined,
     availability:    typeof meta['availability'] === 'number' ? ( meta['availability'] as number ) : undefined,
     description:     str( meta['description'] ),
     planId:          str( meta['planId'] ),

--- a/src/cognition/agency/engines/affordance.synthesizer.ts
+++ b/src/cognition/agency/engines/affordance.synthesizer.ts
@@ -39,6 +39,7 @@ import { CURIOUS_RESOLVED } from '#faculties/known.entity.tracker'
 import { collectGoalTargets } from '#agency/selection.scoring'
 import { readEffectiveParams } from '#cognition/persona.prior'
 import { liveConsequences, enactionFootprint, spokenAtByEntity, CONSEQUENCE_TTL_TICKS, type ConsequenceDescriptor } from '#agency/consequence'
+import { liveSettlements, settlementForce, type SettlementDescriptor } from '#agency/settlement'
 
 /** Default field width for non-innate affordances when no attention metric exists. */
 const DEFAULT_ATTENTION_CAP = 5
@@ -72,6 +73,10 @@ export class AffordanceSynthesizer implements CognitiveEngine {
 
   /** Ticks an act stays satiating (engine-config-action-selector.repeatWindowTicks). */
   private _satiationWindow: number = CONSEQUENCE_TTL_TICKS
+  /** Verdicts System 2 has already reached and that have not yet aged out.
+   *  Collected once per tick for the same reason `_inFlight` is — `_build` runs
+   *  per candidate and this is a full-entity scan. */
+  private _settled: SettlementDescriptor[] = []
 
   /** Tick of the last thing said to each entity — outlives the descriptor sweep. */
   private _spokenAt: ReadonlyMap<string, number> = new Map()
@@ -134,6 +139,9 @@ export class AffordanceSynthesizer implements CognitiveEngine {
     // candidate whose (schema, target) matches one of these carries a decaying
     // `justEnacted`, so having just done a thing damps doing it again.
     this._inFlight = liveConsequences( state.entities, tick )
+    // What the mind has already decided. Read here so a verdict reaches the
+    // competition as a force in the field rather than a fact about one intent.
+    this._settled = liveSettlements( state.entities, tick )
     // How long this mind sits with something it has already done before doing it
     // again — the tenant's, not the container's. Falls back to the echo TTL only
     // when unseeded, so a bare harness behaves as before.
@@ -421,6 +429,11 @@ export class AffordanceSynthesizer implements CognitiveEngine {
       speaks ? this._spokeAnywhereAt : undefined,
     )
 
+    // The mirror of satiation: having thought this through holds the choice for
+    // a while, and fades. Keyed exactly as `justEnacted` is, so an objectless
+    // verdict cannot leak onto an act that has an object.
+    const settled = settlementForce( this._settled, schema.id, ctx.targetEntityId, tick )
+
     const key    = ctx.targetEntityId ?? ctx.evokedBy ?? schema.id
     const source = ctx.source ?? schema.source
     // A non-default-source candidate (ideomotor) gets a distinct id so it can coexist
@@ -444,6 +457,7 @@ export class AffordanceSynthesizer implements CognitiveEngine {
       ...( availability < 1 ? { availability } : {} ),
       ...( socialPrior !== 0 ? { socialPrior } : {} ),
       ...( justEnacted > 0 ? { justEnacted } : {} ),
+      ...( settled > 0 ? { settled } : {} ),
       planBias:        ctx.planBias,
       willBias:        ctx.willBias,
       planId:          ctx.planId,
@@ -476,6 +490,10 @@ export class AffordanceSynthesizer implements CognitiveEngine {
         // it never was: this is the state hop between synthesis and the
         // competition, and `justEnacted` did not cross it.
         ...( a.justEnacted !== undefined ? { justEnacted: a.justEnacted } : {} ),
+        // The verdict's standing weight — same hop, same rule. A field the
+        // synthesizer computes and the entity does not carry is a field the
+        // competition never sees, which is how `justEnacted` stayed dormant.
+        ...( a.settled !== undefined ? { settled: a.settled } : {} ),
         planBias:        a.planBias,
         willBias:        a.willBias,
         planId:          a.planId,

--- a/src/cognition/agency/engines/deliberation.engine.ts
+++ b/src/cognition/agency/engines/deliberation.engine.ts
@@ -31,6 +31,7 @@ import type { CognitiveBus } from '#cognition/bus'
 import type { CognitiveEngine, EngineResult } from '#cognition/types'
 import type { CognitiveEventSchema } from '#cognition/schema.registry'
 import { revokedIntentIds, revocationId } from '#agency/revocation'
+import { settlementEntity, expiredSettlementIds, SETTLEMENT_TTL_TICKS } from '#agency/settlement'
 import { nameOf, isReferentId } from '#cognition/social.identity'
 
 // ── Minimal structural view of the executive's facet machinery ───────────────
@@ -99,7 +100,10 @@ export class DeliberationEngine implements CognitiveEngine {
     // to let go of it — and the tombstone with it. We never deliberate a
     // revoked intent.
     const revoked = revokedIntentIds( state.entities, tick )
-    const del: string[] = []
+    // Aged-out verdicts go with them. Nothing else owns settlements, and a
+    // question whose settlement has expired must be genuinely open again — not
+    // merely inert-but-present, which would leave the state growing forever.
+    const del: string[] = expiredSettlementIds( state.entities, tick )
 
     // One deliberation per tick (the serial bottleneck).
     let target: { id: string; meta: Record<string, unknown> } | null = null
@@ -137,7 +141,15 @@ export class DeliberationEngine implements CognitiveEngine {
 
     return {
       commands: {
-        set:     [ this._commit( id, meta, chosen, candidates, 'facet') ],
+        set: [
+          this._commit( id, meta, chosen, candidates, 'facet'),
+          // The verdict's trace in the field it was called in to resolve.
+          // Written ONLY here, on the path where System 2 actually thought —
+          // the no-executive path below confirms the substrate's winner without
+          // reaching a conclusion, and a mind should not be held to a verdict it
+          // never formed.
+          this._settle( chosen, candidates, tick ),
+        ],
         ...( del.length > 0 ? { delete: del } : {} ),
         metrics: [ [ 'agency.deliberation.count', 1 ] ],
       },
@@ -185,6 +197,25 @@ export class DeliberationEngine implements CognitiveEngine {
       logger.warn(`[deliberation] facet unavailable, confirming winner: ${ err instanceof Error ? err.message : String( err ) }`)
       return provisional
     }
+  }
+
+  /**
+   * Record that this contest was weighed and settled.
+   *
+   * Keyed on what WON, not on the rival set, so a slightly differently-framed
+   * contest still meets a verdict the mind has already reached — the rivals ride
+   * along as the introspectable reason rather than as a matching key.
+   */
+  private _settle( chosen: string, candidates: Candidate[], tick: Tick ): EntityInput {
+    const cand = candidates.find( c => c.schema === chosen )
+    const over = candidates.filter( c => c.schema !== chosen ).map( c => c.schema )
+    return settlementEntity({
+      schema:         chosen,
+      targetEntityId: cand?.targetEntityId,
+      ...( over.length > 0 ? { over } : {} ),
+      tick,
+      expiresAt:      tick + SETTLEMENT_TTL_TICKS,
+    })
   }
 
   /** Write the deliberating intent back as 'selected' with the chosen action. */

--- a/src/cognition/agency/selection.scoring.ts
+++ b/src/cognition/agency/selection.scoring.ts
@@ -77,6 +77,20 @@ export interface ScoreWeights {
    * pressing reason to speak again still wins.
    */
   repeat:  number
+  /**
+   * How strongly a verdict System 2 already reached holds the competition.
+   *
+   * Peer of `will` and `repeat` in magnitude, and for the same reason each of
+   * those is: having thought a choice through should weigh about what willing it
+   * does, and no more. Large enough that the settled option clears the
+   * selector's ambiguity gate (0.06) for most of the settlement's life, so the
+   * same question is not re-deliberated every few ticks; small enough that a
+   * genuinely pressing affordance — threat, a person waiting, a drive gone
+   * urgent — still out-competes a standing verdict.
+   *
+   * Decays to 0 with the settlement, so the question re-opens on its own.
+   */
+  settled: number
 }
 
 export const DEFAULT_WEIGHTS: ScoreWeights = {
@@ -92,6 +106,7 @@ export const DEFAULT_WEIGHTS: ScoreWeights = {
   inhib:   0.30,
   risk:    0.20,
   repeat:  0.30,
+  settled: 0.30,
 }
 
 /**
@@ -190,6 +205,7 @@ export function scoreAffordance(
     - w.inhib   * bias.inhibition
     - w.risk    * risk( a, bias )
     - w.repeat  * ( a.justEnacted ?? 0 )
+    + w.settled * ( a.settled ?? 0 )
   )
   // POLICY_REAFFERENCE P2 — policy availability damps a POSITIVE activation only,
   // never flipping its sign: a refused ability competes weakly (so it is rarely

--- a/src/cognition/agency/settlement.ts
+++ b/src/cognition/agency/settlement.ts
@@ -1,0 +1,193 @@
+// ─────────────────────────────────────────────────────────────
+// src/agency/settlement.ts  —  having thought about it
+// ─────────────────────────────────────────────────────────────
+//
+// The agency has always been able to represent having ACTED. It could not
+// represent having DECIDED.
+//
+// System 2 is recruited when the field is ambiguous — `margin < marginGate` in
+// the ActionSelector, where margin is the activation gap between the top two
+// affordances. The DeliberationEngine then resolves the contest and writes back
+// exactly one thing: that intent flipped to 'selected', carrying `deliberated:
+// true`. Nothing reads `deliberated`. The synthesizer rebuilds the field from
+// scratch next tick, the same rivals score the same, the margin is again below
+// the gate, and the same question is deliberated again.
+//
+// Measured on a live COO over 7 hours: 149 deliberations, median gap between
+// them 17 seconds, 139 of 148 gaps under a minute — one LLM call every ~3 ticks
+// for the whole run, and the single largest line in her cost. She could see it
+// and had no mechanism to leave it:
+//
+//   "Nothing has changed since my last ten deliberation cycles. Goal-7 is
+//    externally blocked — this is a fact, not a diagnosis I need to reach again."
+//   "I have composed the same message to FKEM across twelve deliberation cycles
+//    and not sent it."
+//   "There is nothing left to deliberate. I am looking."
+//
+// So: a settlement is the trace a verdict leaves in the field it was called in
+// to resolve. It is the missing peer of a family the engine already has —
+// having acted damps re-acting (`justEnacted`), having spoken damps re-speaking
+// (`spokeAnywhereAt`), having committed can be withdrawn (revocation
+// tombstones) — and having thought damped nothing at all.
+//
+// The mechanism is deliberately ONE quantity doing both jobs. Raising the
+// settled option's activation means (a) the verdict has force, so System 1 does
+// not coin-flip its way to a different answer on the next tick of the same flat
+// field, and (b) the margin to the runner-up widens past the gate, so System 2
+// is not recruited for a question it has already answered. The flatness is what
+// summoned deliberation; the verdict is what gives the field the shape it
+// lacked.
+//
+// And it DECAYS, like everything else here. This is a refractory period, not a
+// lock — the user's objection to "a hard conditional gate that does not promise
+// any flexibility or dynamism of the mind" is the whole design constraint. As
+// the settlement ages the field flattens again and the question genuinely
+// re-opens; a rupture revokes it outright through the machinery that already
+// exists. A mind may always change its mind. It should not have to reach the
+// same conclusion every three seconds to keep holding it.
+// ─────────────────────────────────────────────────────────────
+
+import type { EntityInput, Tick } from '#core/types'
+
+export const SETTLEMENT_TYPE = 'agency.settlement'
+
+/**
+ * Ticks a verdict holds before the question is genuinely open again.
+ *
+ * Set to the satiation window rather than the echo window, and the symmetry is
+ * the argument: having thought about something should hold about as long as
+ * having done it. The echo window (`CONSEQUENCE_TTL_TICKS`, 30) answers "could
+ * the world still be replying to me" — a different and necessarily shorter
+ * question that has nothing to do with whether a choice is settled.
+ *
+ * At the COO's observed rate (~5s/tick) this is roughly five minutes of held
+ * verdict, against a mind that was re-deciding every three ticks.
+ */
+export const SETTLEMENT_TTL_TICKS = 60
+
+export interface SettlementDescriptor {
+  /** The act that won the contest. */
+  schema:          string
+  /** Its object, when it has one — keyed exactly as satiation is, on purpose. */
+  targetEntityId?: string
+  /**
+   * The rivals it was weighed against.
+   *
+   * Not used for matching — a settlement is keyed on what WON, so a slightly
+   * differently-framed contest still meets a verdict the mind has already
+   * reached. Carried because "I decided this over that" is the introspectable
+   * fact, and a settlement with no memory of what it beat is a preference with
+   * no reason attached.
+   */
+  over?:           readonly string[]
+  tick:            Tick
+  expiresAt:       Tick
+}
+
+/** Stable id — one settlement per (schema, target), so re-deciding refreshes it. */
+export function settlementId( schema: string, targetEntityId?: string ): string {
+  return `agency-settlement-${ schema }${ targetEntityId ? `-${ targetEntityId }` : '' }`
+}
+
+/** Build the settlement entity. Ordinary state, so it snapshots and replays (FN9). */
+export function settlementEntity( d: SettlementDescriptor ): EntityInput {
+  return {
+    id:   settlementId( d.schema, d.targetEntityId ),
+    type: SETTLEMENT_TYPE,
+    metadata: { ...d, ...( d.over ? { over: [ ...d.over ] } : {} ) },
+  }
+}
+
+/**
+ * Read a settlement back off entity metadata.
+ *
+ * Decoded field-for-field, including `over`. A value written by one side and
+ * never read by the other is the defect shape this codebase has now hit six
+ * times, and it is the exact defect this module exists to fix — `deliberated:
+ * true` was written on every deliberated intent and read by nobody.
+ */
+export function readSettlement(
+  m: ReadonlyMap<string, unknown> | Record<string, unknown> | undefined,
+): SettlementDescriptor | null {
+  const meta = ( m instanceof Map ? Object.fromEntries( m ) : m ?? {} ) as Record<string, unknown>
+  const schema = typeof meta['schema'] === 'string' ? meta['schema'] as string : undefined
+  if( !schema ) return null
+
+  const over = Array.isArray( meta['over'] )
+    ? ( meta['over'] as unknown[] ).filter( ( x ): x is string => typeof x === 'string' )
+    : undefined
+
+  return {
+    schema,
+    targetEntityId: typeof meta['targetEntityId'] === 'string' ? meta['targetEntityId'] as string : undefined,
+    ...( over && over.length > 0 ? { over } : {} ),
+    tick:      typeof meta['tick']      === 'number' ? meta['tick']      as number : 0,
+    expiresAt: typeof meta['expiresAt'] === 'number' ? meta['expiresAt'] as number : 0,
+  }
+}
+
+/** The live (unexpired) settlements in frozen state, in stable id order. */
+export function liveSettlements(
+  entities: ReadonlyMap<string, { type: string; metadata?: ReadonlyMap<string, unknown> | Record<string, unknown> }>,
+  tick:     Tick,
+): SettlementDescriptor[] {
+  const out: Array<{ id: string; d: SettlementDescriptor }> = []
+
+  for( const [ id, e ] of entities ){
+    if( e.type !== SETTLEMENT_TYPE ) continue
+    const d = readSettlement( e.metadata )
+    if( !d ) continue
+    // Stamped LATER than now ⇒ restored from a previous session, where the tick
+    // counter restarts at 1 on wake. Without this a woken mind reads every
+    // settlement it ever made as freshly decided and cannot deliberate at all.
+    // The same trap `liveConsequences` documents, and the same fix.
+    if( d.tick > tick ) continue
+    if( tick < d.expiresAt ) out.push({ id, d })
+  }
+
+  return out.sort( ( a, b ) => ( a.id < b.id ? -1 : a.id > b.id ? 1 : 0 ) ).map( x => x.d )
+}
+
+/** Settlement ids that have aged out — swept by the DeliberationEngine. */
+export function expiredSettlementIds(
+  entities: ReadonlyMap<string, { type: string; metadata?: ReadonlyMap<string, unknown> | Record<string, unknown> }>,
+  tick:     Tick,
+): string[] {
+  const out: string[] = []
+  for( const [ id, e ] of entities ){
+    if( e.type !== SETTLEMENT_TYPE ) continue
+    const d = readSettlement( e.metadata )
+    if( d && tick >= d.expiresAt ) out.push( id )
+  }
+  return out
+}
+
+/**
+ * How much of a verdict on this (schema, target) is still standing, 1 → 0.
+ *
+ * Linear decay over the window, matching `enactionFootprint` — the two are
+ * mirror images and should feel the same from inside: one is the fading pull
+ * not to repeat an act, this is the fading weight of having already chosen.
+ *
+ * An objectless act matches an objectless settlement only. Deciding to `rest`
+ * says nothing about whether to `reach-out` to Ada, and a verdict that leaked
+ * across objects would be a mind that mistakes one question for another.
+ */
+export function settlementForce(
+  settlements:    readonly SettlementDescriptor[],
+  schema:         string,
+  targetEntityId: string | undefined,
+  tick:           Tick,
+  windowTicks:    number = SETTLEMENT_TTL_TICKS,
+): number {
+  if( windowTicks <= 0 ) return 0
+
+  let strongest = 0
+  for( const s of settlements ){
+    if( s.schema !== schema || s.targetEntityId !== targetEntityId ) continue
+    const remaining = ( windowTicks - ( tick - s.tick ) ) / windowTicks
+    if( remaining > strongest ) strongest = remaining
+  }
+
+  return strongest < 0 ? 0 : strongest > 1 ? 1 : strongest
+}

--- a/src/cognition/agency/types.ts
+++ b/src/cognition/agency/types.ts
@@ -184,6 +184,26 @@ export interface Affordance {
    * each time as though it were the first.
    */
   justEnacted?:    number
+  /**
+   * How much of a DELIBERATED verdict on this act is still standing, 1 → 0.
+   *
+   * The mirror of `justEnacted`: that one is the fading pull not to repeat
+   * something done, this is the fading weight of having already chosen. Set
+   * when System 2 resolved a contest in this act's favour and the settlement
+   * has not yet aged out.
+   *
+   * It does two things with one quantity, which is why it is a quantity and not
+   * a flag. The verdict gets force, so System 1 does not coin-flip its way to a
+   * different answer on the next tick of the same flat field; and the margin to
+   * the runner-up widens past the selector's gate, so System 2 is not recruited
+   * for a question it has already answered. Flatness is what summons
+   * deliberation — the verdict is what gives the field the shape it lacked.
+   *
+   * Without it, a live COO deliberated 149 times in 7 hours, median 17s apart,
+   * re-reaching the same conclusion about an externally-blocked goal until she
+   * wrote "this is a fact, not a diagnosis I need to reach again".
+   */
+  settled?:        number
   /** Provenance: the plan whose frontier step projected this affordance. */
   planId?:         string
   /** Provenance: the frontier step id — flows through to action.outcome so the plan advances. */

--- a/src/cognition/sense.boundary.ts
+++ b/src/cognition/sense.boundary.ts
@@ -63,6 +63,7 @@
 
 import { CONSEQUENCE_TYPE } from '#agency/consequence'
 import { REVOCATION_TYPE }  from '#agency/revocation'
+import { SETTLEMENT_TYPE }  from '#agency/settlement'
 
 /**
  * Entity types that ARE the mind — written by its own engines about its own
@@ -114,6 +115,7 @@ export const MIND_OWN_ENTITY_TYPES: ReadonlySet<string> = new Set([
   'action.unresolved', 'action.unaddressed',
   CONSEQUENCE_TYPE,   // forward-model records  (EXAFFERENCE P1/P2)
   REVOCATION_TYPE,    // commitment tombstones  (EXAFFERENCE P4)
+  SETTLEMENT_TYPE,    // verdicts System 2 reached — having thought about it
 
   // ── substrate ─────────────────────────────────────────────────
   // Its configuration and its identity are constitutive of it, not events in

--- a/tests/integration/agency.settles-a-question.test.ts
+++ b/tests/integration/agency.settles-a-question.test.ts
@@ -1,0 +1,213 @@
+// ─────────────────────────────────────────────────────────────
+// tests/integration/agency.settles-a-question.test.ts
+// ─────────────────────────────────────────────────────────────
+/**
+ * The loop, end to end — and that it closes.
+ *
+ * The pathology in full: the selector recruits System 2 when `margin <
+ * marginGate` (0.06), margin being the activation gap between the top two
+ * affordances. A field whose options are variations on one theme shares nearly
+ * every scoring term, so the margin is structurally tiny and the gate is open
+ * every tick. Deliberation resolves the contest, writes `deliberated: true` on
+ * that one intent, and returns. The synthesizer rebuilds the field from scratch,
+ * the same rivals score the same, the margin is again under the gate, and the
+ * mind deliberates the same question again.
+ *
+ * Measured on a live COO: 149 deliberations in 7 hours, median gap 17 seconds,
+ * 139 of 148 gaps under a minute. She wrote, in her own reasoning: "Nothing has
+ * changed since my last ten deliberation cycles. Goal-7 is externally blocked —
+ * this is a fact, not a diagnosis I need to reach again."
+ *
+ * This file runs the actual engines against each other rather than asserting on
+ * either one alone, because every defect in this family has been a value that
+ * one engine produced and another did not read.
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { ReadonlySimulationState, SimulationContext, EntityInput } from '#core/types'
+import { DeliberationEngine, type DeliberationFacetProvider } from '#agency/engines/deliberation.engine'
+import { AffordanceSynthesizer } from '#agency/engines/affordance.synthesizer'
+import { readAffordance } from '#agency/engines/action.selector'
+import { scoreAffordance, DEFAULT_WEIGHTS, type BiasContext } from '#agency/selection.scoring'
+import {
+  SETTLEMENT_TYPE, SETTLEMENT_TTL_TICKS, readSettlement, liveSettlements, settlementId,
+} from '#agency/settlement'
+
+const CTX = {} as unknown as SimulationContext
+
+type Ent = { id: string; type: string; metadata?: Record<string, unknown> }
+
+function stateOf( tick: number, ents: Ent[], metrics: Record<string, number> = {} ): ReadonlySimulationState {
+  const entities = new Map<string, unknown>()
+  for( const e of ents )
+    entities.set( e.id, { ...e, createdAt: 0, updatedAt: 0 } )
+  return {
+    tick, time: 0, entities, metrics: new Map( Object.entries( metrics ) ),
+  } as unknown as ReadonlySimulationState
+}
+
+/** A facet that always reaches the same verdict — which is the real situation. */
+function decides( choice: string ): DeliberationFacetProvider {
+  return {
+    spawnFacet() {
+      let listener: ( ( d: { decision: unknown } ) => void ) | null = null
+      return {
+        attention: 'available',
+        handle: {
+          setFocus() {},
+          subscribe( l ) { listener = l; return () => { listener = null } },
+          async report() { listener?.({ decision: { actions: [ { type: choice } ] } }) },
+          destroy() {},
+        },
+      }
+    },
+  }
+}
+
+const CANDIDATES = [
+  { schema: 'withdraw' },
+  { schema: 'reach-out', targetEntityId: 'ke:fkem' },
+  { schema: 'inspect',   targetEntityId: 'ke:room' },
+]
+
+const deliberatingIntent = ( tick: number ): Ent => ({
+  id: `agency-intent-${ tick }`, type: 'agency.intent',
+  metadata: { status: 'deliberating', schema: 'reach-out', parameters: {}, candidates: CANDIDATES, tick },
+})
+
+const bias = (): BiasContext => ({
+  valence: 0, threat: 0, inhibition: 0,
+  drives: { energy: 0, sleep: 0, social: 0, stress: 0 },
+  goalTargets: new Map(),
+} as unknown as BiasContext )
+
+// ─────────────────────────────────────────────────────────────
+
+describe('deliberating leaves a trace in the field it resolved', () => {
+  it('writes a settlement naming the act that won and the rivals it beat', async () => {
+    const eng = new DeliberationEngine()
+    eng.attachExecutive( decides('withdraw') )
+
+    const set = ( await eng.react( 0, 100, stateOf( 100, [ deliberatingIntent( 100 ) ] ), CTX ) ).commands?.set
+    const settlement = ( set ?? [] ).find( e => e.type === SETTLEMENT_TYPE )
+
+    expect( settlement, 'System 2 reached a verdict and the field learned nothing').toBeDefined()
+
+    const d = readSettlement( settlement!.metadata )
+    expect( d?.schema ).toBe('withdraw')
+    expect( d?.expiresAt ).toBe( 100 + SETTLEMENT_TTL_TICKS )
+    expect( d?.over, 'what it was chosen OVER is the introspectable reason')
+      .toEqual( [ 'reach-out', 'inspect' ] )
+  })
+
+  it('does NOT settle when no executive thought about it', async () => {
+    // The no-executive path confirms the substrate's provisional winner without
+    // reaching a conclusion. A mind must not be held to a verdict it never formed.
+    const set = ( await new DeliberationEngine()
+      .react( 0, 100, stateOf( 100, [ deliberatingIntent( 100 ) ] ), CTX ) ).commands?.set
+
+    expect( ( set ?? [] ).some( e => e.type === SETTLEMENT_TYPE ) ).toBe( false )
+  })
+
+  it('and the settlement it wrote actually widens the margin next tick', async () => {
+    // The whole point. The verdict must reach the competition as a force, or the
+    // gate is open again on the very next tick and nothing has changed.
+    const eng = new DeliberationEngine()
+    eng.attachExecutive( decides('withdraw') )
+
+    const settlement = ( ( await eng.react(
+      0, 100, stateOf( 100, [ deliberatingIntent( 100 ) ] ), CTX ) ).commands?.set ?? [] )
+      .find( e => e.type === SETTLEMENT_TYPE )!
+
+    // Next tick: the synthesizer rebuilds the field, now with the verdict in state.
+    const withVerdict = await new AffordanceSynthesizer().react( 0, 101, stateOf( 101,
+      [ { id: settlement.id, type: settlement.type, metadata: settlement.metadata as Record<string, unknown> } ],
+      { 'energy.level': 60 } ), CTX )
+    const without = await new AffordanceSynthesizer().react(
+      0, 101, stateOf( 101, [], { 'energy.level': 60 } ), CTX )
+
+    const pick = ( r: { commands?: { set?: EntityInput[] } } ) =>
+      ( r.commands?.set ?? [] ).find( e => e.metadata?.['schema'] === 'withdraw' )!
+    const scoreOf = ( e: EntityInput ) =>
+      scoreAffordance( readAffordance( e.id, e.metadata ), bias(), DEFAULT_WEIGHTS )
+
+    const gain = scoreOf( pick( withVerdict ) ) - scoreOf( pick( without ) )
+    expect( gain, 'a verdict that does not clear the 0.06 ambiguity gate cannot stop the loop')
+      .toBeGreaterThan( 0.06 )
+  })
+
+  it('sweeps its own aged-out verdicts, so state does not grow forever', async () => {
+    const stale = {
+      id: settlementId('withdraw'), type: SETTLEMENT_TYPE,
+      metadata: { schema: 'withdraw', tick: 10, expiresAt: 40 },
+    }
+    const res = await new DeliberationEngine().react( 0, 200, stateOf( 200, [ stale ] ), CTX )
+    expect( res.commands?.delete ).toContain( stale.id )
+  })
+
+  it('re-deciding refreshes one settlement rather than piling up new ones', async () => {
+    const eng = new DeliberationEngine()
+    eng.attachExecutive( decides('withdraw') )
+
+    const first = ( ( await eng.react( 0, 100, stateOf( 100, [ deliberatingIntent( 100 ) ] ), CTX ) )
+      .commands?.set ?? [] ).find( e => e.type === SETTLEMENT_TYPE )!
+    const again = ( ( await eng.react( 0, 400, stateOf( 400, [ deliberatingIntent( 400 ) ] ), CTX ) )
+      .commands?.set ?? [] ).find( e => e.type === SETTLEMENT_TYPE )!
+
+    expect( again.id ).toBe( first.id )
+    expect( readSettlement( again.metadata )?.expiresAt ).toBe( 400 + SETTLEMENT_TTL_TICKS )
+  })
+})
+
+describe('and the mind can still change its mind', () => {
+  it('the verdict fades on its own, re-opening the question', async () => {
+    const held = ( tick: number ) => liveSettlements( new Map([ [ settlementId('withdraw'),
+      { type: SETTLEMENT_TYPE, metadata: { schema: 'withdraw', tick: 100, expiresAt: 160 } } ] ]), tick )
+
+    expect( held( 101 ) ).toHaveLength( 1 )
+    expect( held( 200 ), 'a verdict must not be permanent — the question comes back').toHaveLength( 0 )
+  })
+
+  it('a verdict formed before the world changed does not survive the change', async () => {
+    // The failure this shares with the FKEM incident: a decision made in one
+    // situation, executed into another, with nothing looking in between. A hard
+    // exafferent rupture means the premises the mind decided on were just
+    // contradicted, so the settlement lapses with them — and NOT only when
+    // something happens to be mid-deliberation, since the whole point of a
+    // settlement is that it outlives the intent that formed it.
+    const { ActionSelector } = await import('#agency/engines/action.selector')
+
+    const settlement: Ent = {
+      id: settlementId('withdraw'), type: SETTLEMENT_TYPE,
+      metadata: { schema: 'withdraw', tick: 100, expiresAt: 100 + SETTLEMENT_TTL_TICKS },
+    }
+    // A maximally surprising exafferent percept — read straight off frozen state
+    // by `computeRupture`, so this does not depend on bus plumbing.
+    const rupturing: Ent = {
+      id: 'percept-1', type: 'percept',
+      metadata: { provenance: 'exafferent', salience: 1, tick: 110, content: 'the world just changed' },
+    }
+
+    const res = await new ActionSelector().react(
+      0, 110, stateOf( 110, [ settlement, rupturing ], { 'situation.stability': 1 } ), CTX )
+
+    expect( res.commands?.delete, 'the verdict outlived the situation that produced it')
+      .toContain( settlement.id )
+  })
+
+  it('but an ordinary tick leaves a standing verdict alone', async () => {
+    // The counterpart, and what keeps the above from passing for the wrong
+    // reason: without a rupture the settlement must survive untouched.
+    const { ActionSelector } = await import('#agency/engines/action.selector')
+
+    const settlement: Ent = {
+      id: settlementId('withdraw'), type: SETTLEMENT_TYPE,
+      metadata: { schema: 'withdraw', tick: 100, expiresAt: 100 + SETTLEMENT_TTL_TICKS },
+    }
+
+    const res = await new ActionSelector().react(
+      0, 110, stateOf( 110, [ settlement ], { 'situation.stability': 1 } ), CTX )
+
+    expect( res.commands?.delete ?? [] ).not.toContain( settlement.id )
+  })
+})

--- a/tests/unit/agency.field-crossing.test.ts
+++ b/tests/unit/agency.field-crossing.test.ts
@@ -22,6 +22,9 @@
  *     `metadata.candidates` and rendered by the DeliberationEngine as `— <what>`.
  *     The candidate list the mind reasons over listed acts with no meanings.
  *
+ * `settled` is the fourth, and the first to arrive with its decoder already
+ * written rather than months after the mechanism shipped dark.
+ *
  * They survived because the units were tested and the SEAM was not:
  * `agency.repetition.test.ts` builds Affordance literals in memory and calls
  * `scoreAffordance` directly, which is a true statement about the scorer and
@@ -35,6 +38,7 @@ import { AffordanceSynthesizer } from '#agency/engines/affordance.synthesizer'
 import { readAffordance } from '#agency/engines/action.selector'
 import { scoreAffordance, DEFAULT_WEIGHTS } from '#agency/selection.scoring'
 import type { BiasContext } from '#agency/selection.scoring'
+import { settlementId, SETTLEMENT_TYPE, SETTLEMENT_TTL_TICKS } from '#agency/settlement'
 
 const CTX = {} as unknown as SimulationContext
 
@@ -147,6 +151,55 @@ describe('the hop between synthesis and selection', () => {
 
     expect( readAffordance( entity.id, entity.metadata ).description )
       .toBe('give the plants water')
+  })
+
+  it('carries a settled verdict across, so System 2 is not re-recruited for an answered question', async () => {
+    // The fourth field to make this crossing, added WITH its decoder rather than
+    // after someone notices the mechanism has been dark for months. A live COO
+    // deliberated 149 times in 7 hours, median 17s apart, because a verdict left
+    // no trace in the field it was called in to resolve.
+    const synth = new AffordanceSynthesizer()
+    const state = makeState({
+      tick: 110,
+      metrics: { 'energy.level': 60 },
+      entities: [ {
+        id: settlementId('express'), type: SETTLEMENT_TYPE,
+        metadata: { schema: 'express', tick: 100, expiresAt: 100 + SETTLEMENT_TTL_TICKS },
+      } ],
+    })
+
+    const entity = bySchema( ( await synth.react( 0, 110, state, CTX ) ).commands?.set, 'express')!
+
+    expect( entity.metadata?.['settled'], 'the verdict must be WRITTEN onto the affordance')
+      .toBeGreaterThan( 0 )
+    expect( readAffordance( entity.id, entity.metadata ).settled, 'and READ back')
+      .toBeGreaterThan( 0 )
+
+    // And it must actually move the score, or the margin never widens and the
+    // selector recruits System 2 again on the next identical tick.
+    const undecided = bySchema(
+      ( await new AffordanceSynthesizer().react(
+        0, 110, makeState({ tick: 110, metrics: { 'energy.level': 60 } }), CTX ) ).commands?.set,
+      'express')!
+
+    const scoreOf = ( e: EntityInput ) =>
+      scoreAffordance( readAffordance( e.id, e.metadata ), bias(), DEFAULT_WEIGHTS )
+
+    expect( scoreOf( entity ) - scoreOf( undecided ) ).toBeGreaterThan( 0.06 )
+  })
+
+  it('a verdict that has aged out leaves no trace — the question is open again', async () => {
+    const synth = new AffordanceSynthesizer()
+    const res = await synth.react( 0, 200, makeState({
+      tick: 200,
+      metrics: { 'energy.level': 60 },
+      entities: [ {
+        id: settlementId('express'), type: SETTLEMENT_TYPE,
+        metadata: { schema: 'express', tick: 100, expiresAt: 100 + SETTLEMENT_TTL_TICKS },
+      } ],
+    }), CTX )
+
+    expect( bySchema( res.commands?.set, 'express')?.metadata?.['settled'] ).toBeUndefined()
   })
 
   it('carries policy availability across, so a refused ability competes weakly', () => {

--- a/tests/unit/agency.settlement.test.ts
+++ b/tests/unit/agency.settlement.test.ts
@@ -1,0 +1,182 @@
+// ─────────────────────────────────────────────────────────────
+// tests/unit/agency.settlement.test.ts
+// ─────────────────────────────────────────────────────────────
+/**
+ * Having thought about it.
+ *
+ * The agency could represent having ACTED and could not represent having
+ * DECIDED. System 2 was recruited on a flat field, resolved the contest, wrote
+ * `deliberated: true` on that one intent — and nothing read it. The synthesizer
+ * rebuilt the field from scratch next tick, the same rivals scored the same, the
+ * margin was again under the gate, and the same question was deliberated again.
+ *
+ * Measured on a live COO over 7 hours: 149 deliberations, median gap 17s, 139 of
+ * 148 gaps under a minute. She could see the loop and had no mechanism to leave
+ * it — "Nothing has changed since my last ten deliberation cycles. Goal-7 is
+ * externally blocked — this is a fact, not a diagnosis I need to reach again."
+ *
+ * A settlement is the trace a verdict leaves in the field it was called in to
+ * resolve, and it is one quantity doing both jobs: the verdict gets force, and
+ * the margin to the runner-up widens past the gate that summons System 2.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  settlementEntity, readSettlement, liveSettlements, settlementForce,
+  expiredSettlementIds, settlementId, SETTLEMENT_TYPE, SETTLEMENT_TTL_TICKS,
+  type SettlementDescriptor,
+} from '#agency/settlement'
+import { scoreAffordance, DEFAULT_WEIGHTS } from '#agency/selection.scoring'
+import type { Affordance } from '#agency/types'
+
+const settled = ( over: Partial<SettlementDescriptor> = {} ): SettlementDescriptor => ({
+  schema: 'reach-out', targetEntityId: 'ke:ada',
+  tick: 100, expiresAt: 100 + SETTLEMENT_TTL_TICKS, ...over,
+})
+
+const entities = ( ...ds: SettlementDescriptor[] ) =>
+  new Map( ds.map( d => {
+    const e = settlementEntity( d )
+    return [ e.id, { type: e.type, metadata: e.metadata as Record<string, unknown> } ]
+  }) )
+
+describe('a verdict already reached', () => {
+  it('holds strongly right after it is made, and fades on its own', () => {
+    const s = [ settled() ]
+    expect( settlementForce( s, 'reach-out', 'ke:ada', 100 ) ).toBeCloseTo( 1, 5 )
+    expect( settlementForce( s, 'reach-out', 'ke:ada', 130 ) ).toBeCloseTo( 0.5, 5 )
+    expect( settlementForce( s, 'reach-out', 'ke:ada', 160 ) ).toBe( 0 )
+    expect( settlementForce( s, 'reach-out', 'ke:ada', 999 ),
+      'a verdict must not outlive its window — this is a refractory period, not a lock').toBe( 0 )
+  })
+
+  it('does not leak onto a different question', () => {
+    const s = [ settled() ]
+    expect( settlementForce( s, 'reach-out', 'ke:bob', 101 ),
+      'deciding about Ada says nothing about Bob').toBe( 0 )
+    expect( settlementForce( s, 'inspect', 'ke:ada', 101 ),
+      'deciding to reach out says nothing about inspecting').toBe( 0 )
+  })
+
+  it('keeps objectless verdicts separate from ones with an object', () => {
+    const s = [ settled({ schema: 'rest', targetEntityId: undefined }) ]
+    expect( settlementForce( s, 'rest', undefined, 101 ) ).toBeGreaterThan( 0 )
+    expect( settlementForce( s, 'rest', 'ke:ada', 101 ) ).toBe( 0 )
+  })
+})
+
+describe('the settlement entity', () => {
+  it('survives the round-trip — written AND read back, every field', () => {
+    // The defect shape this codebase has hit six times, and precisely the one
+    // this module exists to fix: `deliberated: true` was written on every
+    // deliberated intent and decoded by nobody.
+    const d = settled({ over: [ 'inspect', 'withdraw' ] })
+    const back = readSettlement( settlementEntity( d ).metadata )
+
+    expect( back ).toEqual( d )
+    expect( back?.over, 'the rivals are the introspectable reason — "I chose this OVER that"')
+      .toEqual( [ 'inspect', 'withdraw' ] )
+  })
+
+  it('is keyed on what won, so re-deciding refreshes rather than accumulates', () => {
+    expect( settlementEntity( settled({ tick: 100 }) ).id )
+      .toBe( settlementEntity( settled({ tick: 400 }) ).id )
+    expect( settlementEntity( settled() ).type ).toBe( SETTLEMENT_TYPE )
+  })
+
+  it('reads back from a Map, not just a plain object', () => {
+    // Frozen state hands metadata over as a ReadonlyMap in some paths and a
+    // record in others. A decoder that only handles one silently returns null.
+    const meta = new Map( Object.entries( settlementEntity( settled() ).metadata! ) )
+    expect( readSettlement( meta )?.schema ).toBe('reach-out')
+  })
+})
+
+describe('collecting live settlements', () => {
+  it('drops the ones that have aged out', () => {
+    const live = liveSettlements( entities( settled(), settled({
+      schema: 'inspect', targetEntityId: 'ke:room', tick: 10, expiresAt: 40 }) ), 101 )
+    expect( live.map( s => s.schema ) ).toEqual( [ 'reach-out' ] )
+    expect( expiredSettlementIds( entities( settled({ tick: 10, expiresAt: 40 }) ), 101 ) )
+      .toEqual( [ settlementId('reach-out', 'ke:ada') ] )
+  })
+
+  it('ignores a settlement stamped in the future — the restart trap', () => {
+    // Settlements snapshot with the state and the tick counter restarts at 1 on
+    // wake. Without this guard a woken mind reads every verdict it ever made as
+    // freshly decided and cannot deliberate at all. `liveConsequences` documents
+    // the same trap after a Will spent a whole session believing it had just
+    // messaged someone.
+    expect( liveSettlements( entities( settled({ tick: 575, expiresAt: 635 }) ), 1 ) ).toEqual( [] )
+  })
+})
+
+describe('what the verdict does to the competition', () => {
+  const affordance = ( over: Partial<Affordance> = {} ): Affordance => ({
+    id: 'a-1', schema: 'reach-out', source: 'innate', parameters: {},
+    expectedValence: 0, expectedReward: 0.2, cost: 0.1, habitStrength: 0.3,
+    available: true, tags: [], tick: 100, ...over,
+  } as Affordance)
+
+  const bias = {
+    goalTargets: new Map<string, number>(), maxGoalPriority: 0,
+    drives: { energy: 0, sleep: 0, social: 0, stress: 0 }, threat: 0, inhibition: 0,
+  } as never
+
+  it('widens the margin past the gate that summons System 2', () => {
+    // MARGIN_THRESHOLD is 0.06. The whole pathology was a field flat enough to
+    // sit under it every tick, so the verdict has to be what gives the field the
+    // shape it lacked.
+    const plain   = scoreAffordance( affordance(), bias )
+    const decided = scoreAffordance( affordance({ settled: 1 }), bias )
+
+    expect( decided - plain ).toBeCloseTo( DEFAULT_WEIGHTS.settled, 5 )
+    expect( decided - plain,
+      'a fresh verdict must clear the ambiguity gate or nothing stops the loop')
+      .toBeGreaterThan( 0.06 )
+  })
+
+  it('has stopped clearing that gate by the time it has mostly decayed', () => {
+    // The question genuinely re-opens; it does not merely become cheaper to
+    // re-ask. At 20% remaining the boost is 0.06 — exactly the gate — so beyond
+    // that the contest is live again.
+    const plain = scoreAffordance( affordance(), bias )
+    expect( scoreAffordance( affordance({ settled: 0.1 }), bias ) - plain ).toBeLessThan( 0.06 )
+  })
+
+  it('is a weight, not a veto — a pressing rival still wins', () => {
+    // A settled option that could not be out-competed would be the hard
+    // conditional gate this design exists to avoid: no flexibility, no dynamism.
+    //
+    // "Pressing" means what the scorer means by it — a goal pointed at this, and
+    // a drive gone urgent — not merely a high expected reward, which is one of
+    // the weakest levers in the competition (0.25 against `goal` and `social` at
+    // 0.30 each).
+    const pressing = {
+      ...bias as object,
+      goalTargets: new Map([ [ 'ke:bob', 1 ] ]), maxGoalPriority: 1,
+      drives: { energy: 0, sleep: 0, social: 1, stress: 0 },
+    } as never
+
+    const held  = scoreAffordance( affordance({ settled: 1 }), bias )
+    const urgent = scoreAffordance(
+      affordance({ targetEntityId: 'ke:bob', tags: [ 'social' ] }), pressing )
+
+    expect( urgent, 'a standing verdict must not outrank a goal with a drive behind it')
+      .toBeGreaterThan( held )
+  })
+
+  it('but does hold against the flat field that summoned it', () => {
+    // The counterpart, and the actual job: against rivals that differ by almost
+    // nothing — which is what "the field was ambiguous" MEANS — the verdict wins
+    // and keeps winning until it decays.
+    const rival = scoreAffordance( affordance({ id: 'a-2', expectedReward: 0.22 }), bias )
+    const held  = scoreAffordance( affordance({ settled: 0.5 }), bias )
+    expect( held ).toBeGreaterThan( rival )
+  })
+
+  it('leaves a mind that has never deliberated scoring exactly as before', () => {
+    expect( scoreAffordance( affordance({ settled: undefined }), bias ) )
+      .toBe( scoreAffordance( affordance({ settled: 0 }), bias ) )
+  })
+})


### PR DESCRIPTION
The agency could represent having **acted**. It could not represent having **decided**.

## The loop

System 2 is recruited when `margin < marginGate` (0.06) — the activation gap between the top two affordances. A field whose options are variations on one theme (*reach out to Fabrice / reach out to FKEM / inspect / express*) shares nearly every scoring term: same goal, same social, same drive, same plan. **The field is flat by construction**, so the gate is open every tick.

Deliberation then resolves the contest and writes back exactly one thing:

```ts
status: 'selected', deliberated: true      // on that one intent
```

`deliberated` is read by nobody — grep the tree, the only other hit is a comment in the token tracker. The synthesizer rebuilds the field from scratch next tick, the same rivals score the same, the margin is again under the gate, and the same question is deliberated again.

**Measured on a live COO over 7 hours:** 149 deliberations, median gap **17 seconds**, 139 of 148 gaps under a minute. One LLM call every ~3 ticks for the entire run — 83 of her 226 minutes of inference and the single largest line in her cost.

She could see it, and had no mechanism to leave it:

> *"Nothing has changed since my last ten deliberation cycles. Goal-7 is externally blocked — this is a fact, not a diagnosis I need to reach again."*
> *"I have composed the same message to FKEM across twelve deliberation cycles and not sent it."*
> *"There is nothing left to deliberate. I am looking."*

## The cog

A **settlement** is the trace a verdict leaves in the field it was called in to resolve — the missing member of a family the engine already has:

| having… | damps | via |
|---|---|---|
| acted | re-acting | `justEnacted` |
| spoken | re-speaking | `spokeAnywhereAt` |
| committed | re-committing | revocation tombstones |
| **thought** | **re-thinking** | **`settled`** ← this |

Deliberately **one quantity doing both jobs**. Raising the settled option's activation means (a) the verdict has force, so System 1 does not coin-flip its way to a different answer on the next tick of the same flat field, and (b) the margin to the runner-up widens past the gate, so System 2 is not recruited for a question it has already answered. Flatness is what summoned deliberation; the verdict is what gives the field the shape it lacked.

## It is a refractory period, not a lock

A hard conditional gate promising no flexibility or dynamism is precisely what this design exists to avoid.

- **It decays** over the satiation window (60 ticks ≈ 5 min at the COO's observed rate), and the question genuinely re-opens — at 20% remaining the boost is 0.06, exactly the gate.
- **A pressing rival still wins.** A goal pointed at something with a drive behind it out-scores a standing verdict; tested.
- **A rupture lapses it outright** — a decision formed in one situation must not be held in another. Not conditioned on something being mid-deliberation, since the whole point is that a settlement outlives the intent that formed it.
- **Written only where System 2 actually thought.** The no-executive path confirms the substrate's winner without reaching a conclusion, and a mind should not be held to a verdict it never formed.

## Notes

`settled` is the **fourth** field to cross the synthesis→selection hop, and the first to arrive with its decoder already written rather than months after the mechanism shipped dark.

**The sense boundary (#118) caught this mid-build.** An undeclared `agency.settlement` made the mind perceive its own verdicts as world events — and then bind `inspect` to them as objects, recursively:

```
agency-settlement-inspect-agency-settlement-inspect-agency-settlement-express
```

Declared now. That test earning its keep on the first new entity type since it landed is the argument for having written it.

## Tests

`tests/unit/agency.settlement.test.ts` (13) — decay, no cross-question leakage, entity round-trip including `over`, the restart-tick trap, and what it does to the competition.
`tests/integration/agency.settles-a-question.test.ts` (8) — the real engines against each other: the verdict is written, it widens the margin next tick, aged verdicts are swept, re-deciding refreshes rather than accumulates, and rupture lapses it (with the no-rupture counterpart, so the assertion cannot pass vacuously).
`tests/unit/agency.field-crossing.test.ts` (+2) — the hop.

Full suite: 216 files, 1722 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)