### PR TITLE
fix(agency): ask at the door whether this is still what I want to say

### DIFF
--- a/src/cognition/agency/engines/motor.schema.executor.ts
+++ b/src/cognition/agency/engines/motor.schema.executor.ts
@@ -42,8 +42,7 @@ import { revokedIntentIds, revocationId, staleRevocationIds } from '#agency/revo
 import { addressesOf } from '#cognition/social.identity'
 import {
   CONSEQUENCE_TYPE, CONSEQUENCE_TTL_TICKS,
-  consequenceEntity, fnv1a, paramsKey,
-} from '#agency/consequence'
+  consequenceEntity, fnv1a, paramsKey, spokenAtByEntity } from '#agency/consequence'
 
 /** Ticks an async (communicate/external) intent may stay 'awaiting' before it is
  *  abandoned. Exported: the ReafferenceEngine's sensory-confirmation path (P5)
@@ -138,7 +137,16 @@ export class MotorSchemaExecutor implements CognitiveEngine {
    * resolve it as what it is: the intent is freed, and nothing is taught about
    * an ability that was never in question.
    */
-  private _withheld  = new Set<string>()
+  private _withheld  = new Map<string, string>()
+
+  /**
+   * The tick at which each held intent's words were REQUESTED from a facet.
+   *
+   * Authoring is off-tick and can take 10–30s of real time. In that window the
+   * situation the words were composed for can move — and until now nothing
+   * looked. See `situationMoved`.
+   */
+  private _composedAt = new Map<string, Tick>()
 
   constructor( schemas: MotorSchema[] = INNATE_SCHEMAS ){
     for( const s of schemas ) this._schemas.set( s.id, s )
@@ -252,8 +260,10 @@ export class MotorSchemaExecutor implements CognitiveEngine {
     // that will never be said — drop them so the map cannot grow without bound.
     for( const id of this._authored.keys() )
       if( !state.entities.has( id ) ) this._authored.delete( id )
-    for( const id of this._withheld )
+    for( const id of this._withheld.keys() )
       if( !state.entities.has( id ) ) this._withheld.delete( id )
+    for( const id of this._composedAt.keys() )
+      if( !state.entities.has( id ) ) this._composedAt.delete( id )
 
     // ── Timeout stranded async intents ───────────────────────────
     // An 'awaiting' intent whose host/delivery never returned would block the
@@ -274,6 +284,7 @@ export class MotorSchemaExecutor implements CognitiveEngine {
       // letting the clock abandon it as a failure — see `_withheld`.
       if( this._withheld.has( id ) ){
         const intent = readIntent( id, e.metadata )
+        const why    = this._withheld.get( id ) ?? 'I considered speaking and chose not to.'
         set.push({
           id: `agency-outcome-${ tick }-${ id }`,
           type: 'agency.outcome',
@@ -281,7 +292,7 @@ export class MotorSchemaExecutor implements CognitiveEngine {
             schema: intent.schema, intentId: id,
             targetEntityId: intent.targetEntityId,
             withheld: true,
-            description: 'I considered speaking and chose not to.',
+            description: why,
             mode: 'communicate', tick,
             ...( intent.planId ? { planId: intent.planId } : {} ),
             ...( intent.planStepId ? { stepId: intent.planStepId } : {} ),
@@ -586,12 +597,43 @@ export class MotorSchemaExecutor implements CognitiveEngine {
     // authored off-tick and landed since a previous tick asked for them. Neither ⇒
     // request authoring (never awaited here — see `_authoring`) and hold 'awaiting'.
     const authored = str( intent.parameters['content'] ) ?? firstMessage( intent.parameters['messages'] )
+    const fromFacet = !authored
     let bubbles: string[] = authored ? [ authored ] : ( this._authored.get( id ) ?? [] )
     this._authored.delete( id )
     if( bubbles.length === 0 ){
-      this._requestAuthoring( id, intent )
+      this._requestAuthoring( id, intent, tick )
       return false   // nothing to send yet → await
     }
+
+    // ── Is this still what I want to say? ─────────────────────────
+    // Words a facet composed off-tick were formed against the situation as it
+    // stood when they were asked for. Delivering them into a situation that has
+    // since moved is not the act that was decided on — it is an older act
+    // arriving late wearing the present's clothes.
+    //
+    // Live: a COO committed to outreach, was told "I need my full attention on
+    // that right now, will brief you later", acknowledged that correctly — and
+    // 41 seconds later delivered the three-bubble message composed beforehand,
+    // asking for a brain-dump. Same shape at 3am with a colleague who had just
+    // said goodnight: "Night. Talk soon." followed one second later by two
+    // unprompted messages. Satiation cannot damp either, because satiation gates
+    // SELECTION and these were already selected. Nothing looked at the door.
+    //
+    // Only facet-composed words are checked. Content supplied upstream
+    // (`parameters.content`) came from the host or a host-facet with the present
+    // situation in hand, and a reply never reaches this path at all — it is
+    // delivered by the audition facet through the outbox.
+    const moved = fromFacet
+      ? situationMoved( state, intent.targetEntityId, this._composedAt.get( id ) )
+      : null
+    if( moved ){
+      this._withheld.set( id, moved )
+      this._composedAt.delete( id )
+      logger.debug(`[motor] "${ intent.schema }" withheld — ${ moved }`)
+      metrics.push([ 'agency.communicate.stale', 1 ])
+      return false   // resolved as withheld by the sweep: freed, and nothing taught
+    }
+    this._composedAt.delete( id )
 
     const request: ActionRequest = {
       effector,
@@ -644,11 +686,12 @@ export class MotorSchemaExecutor implements CognitiveEngine {
    * per intent — a request already in flight is not duplicated, so the intent may sit
    * 'awaiting' across many ticks with exactly one LLM call behind it.
    */
-  private _requestAuthoring( id: string, intent: Intent ): void {
+  private _requestAuthoring( id: string, intent: Intent, tick: Tick ): void {
     if( !this._author || this._authoring.has( id ) ) return
 
     const name = str( intent.parameters['targetEntityName'] ) ?? intent.targetEntityId ?? 'them'
     this._authoring.add( id )
+    this._composedAt.set( id, tick )
     void this._author
       .authorOutreach( intent.targetEntityId ?? '', name, str( intent.parameters['gist'] ) )
       .then( result => {
@@ -660,7 +703,7 @@ export class MotorSchemaExecutor implements CognitiveEngine {
         // Not a warning: the facet was asked and answered. Choosing not to speak
         // is a decision the mind is entitled to make.
         if( declared ){
-          this._withheld.add( id )
+          this._withheld.set( id, 'I considered speaking and chose not to.')
           logger.debug(`[motor] "${ intent.schema }" withheld — the facet chose silence`)
           return
         }
@@ -875,4 +918,41 @@ function clamp01( n: number ): number {
 }
 function errMsg( err: unknown ): string {
   return err instanceof Error ? err.message : String( err )
+}
+
+/**
+ * Has the situation these words were composed for moved on?
+ *
+ * Returns the mind's own account of what changed, or null if the moment still
+ * stands. The account is what the withheld outcome records, so the mind's
+ * history says why it did not speak rather than merely that it didn't.
+ *
+ * The evidence is `conversation.sent` — the durable record of having spoken,
+ * written by every path that speaks (ProactiveCommunicator, the audition facet,
+ * the outbox). If I have said something to this person SINCE these words were
+ * asked for, then these are not my current words to them: I have already
+ * responded to whatever moved in between, and this is an older turn arriving on
+ * top of a newer one.
+ *
+ * Deliberately not "did they speak since" — `conversation.received` is a
+ * one-shot entity swept on the tick it is scanned, so there is nothing durable
+ * to look back at, and a signal that cannot be read at delivery time is a cog
+ * that ships dark. In practice the two coincide: both live incidents this fixes
+ * had the mind reply first ("Understood. I'm here when you're ready.", "Night.
+ * Talk soon.") and then deliver the stale composition on top of its own answer.
+ *
+ * A missing `composedAt` means the words were never requested through
+ * `_requestAuthoring` — nothing is known about when they were formed, so nothing
+ * is claimed and they go out. Silence beats a guess here: withholding on absent
+ * evidence would mute a mind for reasons it could not name.
+ */
+export function situationMoved(
+  state:          ReadonlySimulationState,
+  targetEntityId: string | undefined,
+  composedAt:     Tick | undefined,
+): string | null {
+  if( composedAt === undefined || !targetEntityId ) return null
+  const spoke = spokenAtByEntity( state.entities as never ).get( targetEntityId )
+  if( spoke === undefined || spoke <= composedAt ) return null
+  return 'I had already spoken to them since composing this, so it was no longer what I had to say.'
 }

--- a/tests/integration/agency.stale-words-stay-unsaid.test.ts
+++ b/tests/integration/agency.stale-words-stay-unsaid.test.ts
@@ -1,0 +1,166 @@
+// ─────────────────────────────────────────────────────────────
+// tests/integration/agency.stale-words-stay-unsaid.test.ts
+// ─────────────────────────────────────────────────────────────
+/**
+ * The door, not the decision.
+ *
+ * `agency.the-moment-passed.test.ts` pins `situationMoved` as a function. This
+ * runs the real executor, because the defect being fixed is not "the predicate
+ * is wrong" — it is that nothing consulted a predicate at all. Words a facet
+ * composed off-tick went straight out whenever they happened to arrive.
+ *
+ * What must hold end to end:
+ *   • stale words are NOT delivered,
+ *   • and resolve as WITHHELD — the mind chose not to say them, it did not fail
+ *     to say them, so `reach-out` takes no competence hit (the #123 mistake),
+ *   • fresh words still go out, or the fix is just a mute button.
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { ReadonlySimulationState, SimulationContext, EntityInput } from '#core/types'
+import { MotorSchemaExecutor } from '#agency/engines/motor.schema.executor'
+import type { OutreachAuthor } from '#agency/engines/motor.schema.executor'
+
+const CTX = {} as unknown as SimulationContext
+interface Mut { tick: number; time: number; entities: Map<string, unknown>; metrics: Map<string, number> }
+
+const freshState = (): Mut =>
+  ({ tick: 0, time: 0, entities: new Map(), metrics: new Map([ [ 'energy.level', 80 ] ]) })
+const frozen = ( s: Mut ) => s as unknown as ReadonlySimulationState
+
+function apply( s: Mut, set?: EntityInput[], del?: string[] ): void {
+  for( const e of set ?? [] ) s.entities.set( e.id, { createdAt: 0, updatedAt: 0, ...e } )
+  for( const id of del ?? [] ) s.entities.delete( id )
+}
+
+function reachOut( s: Mut, id: string ): void {
+  s.entities.set( id, {
+    id, type: 'agency.intent', createdAt: 0, updatedAt: 0,
+    metadata: {
+      schema: 'reach-out', status: 'selected',
+      targetEntityId: 'ke:fabrice', parameters: { targetEntityName: 'Fabrice' },
+      expectedReward: 0.6, expectedValence: 0.2,
+    },
+  } )
+}
+
+/** The mind having spoken to someone — the durable record every speaking path writes. */
+function spokeTo( s: Mut, target: string, tick: number, id = `conversation-sent-${ tick }` ): void {
+  s.entities.set( id, {
+    id, type: 'conversation.sent', createdAt: 0, updatedAt: 0,
+    metadata: { targetEntityId: target, tick },
+  } )
+}
+
+const author = ( bubbles: string[] ): OutreachAuthor => ({ authorOutreach: async () => bubbles })
+
+function executor( sentTexts: string[][] ): MotorSchemaExecutor {
+  const exec = new MotorSchemaExecutor()
+  exec.attachProactiveCommunicator({
+    executeAction: async ( req: { parameters: { messages: string[] } } ) => {
+      sentTexts.push( req.parameters.messages )
+      return { success: true, description: 'sent', commands: { set: [] },
+        feedback: { outcomeQuality: 0.85, surprise: 0, lessons: [] } }
+    },
+  } as never )
+  exec.attachGrants({ isAllowed: () => true } as never )
+  exec.attachOutreachAuthor( author([
+    'Fabrice — here is where I am on the operational picture…',
+    'To turn it into something useful I need a brain-dump from you',
+  ]) )
+  return exec
+}
+
+async function run( s: Mut, exec: MotorSchemaExecutor, ticks: number, onTick?: ( t: number ) => void ) {
+  const outcomes: Array<Record<string, unknown>> = []
+  for( let t = 1; t <= ticks; t++ ){
+    s.tick = t
+    onTick?.( t )
+    const r = await exec.react( 0, t, frozen( s ), CTX )
+    for( const e of r.commands?.set ?? [] )
+      if( e.type === 'agency.outcome') outcomes.push( e.metadata as Record<string, unknown> )
+    apply( s, r.commands?.set, r.commands?.delete )
+    await new Promise( res => setImmediate( res ) )   // let the authoring promise settle
+  }
+  return outcomes
+}
+
+// ─────────────────────────────────────────────────────────────
+
+describe('words the situation has moved past', () => {
+  it('are not delivered — the live Fabrice sequence', async () => {
+    // t1: outreach committed, authoring requested.
+    // t2: the mind answers him ("Understood. I'm here when you're ready.").
+    // t3: the composition, formed at t1, tries to land on top of that answer.
+    const sent: string[][] = []
+    const s = freshState()
+    const exec = executor( sent )
+    reachOut( s, 'intent-1')
+
+    const outcomes = await run( s, exec, 6, t => {
+      if( t === 2 ) spokeTo( s, 'ke:fabrice', 2 )
+    })
+
+    expect( sent, 'the stale composition went out on top of the mind\'s own answer').toEqual( [] )
+
+    const held = outcomes.find( o => o['withheld'] === true )
+    expect( held, 'it must resolve, not rot — a stranded intent blocks the serial mind').toBeDefined()
+    expect( held!['description'] ).toMatch( /already spoken to them since composing/ )
+  })
+
+  it('take no competence hit — the mind did not fail to speak', async () => {
+    // The #123 mistake, which this must not reintroduce: an intent that resolves
+    // as a FAILURE teaches reafference that `reach-out` is unreliable. Choosing
+    // not to say something is a judgement, not an inability.
+    const sent: string[][] = []
+    const s = freshState()
+    const exec = executor( sent )
+    reachOut( s, 'intent-1')
+
+    const outcomes = await run( s, exec, 6, t => {
+      if( t === 2 ) spokeTo( s, 'ke:fabrice', 2 )
+    })
+
+    const held = outcomes.filter( o => o['withheld'] === true )
+    expect( held, 'nothing was withheld, so this asserts nothing').toHaveLength( 1 )
+    expect( held[0]!['success'], 'a withheld turn must not read as a failed act').toBeUndefined()
+    expect( outcomes.some( o => o['success'] === false ),
+      'no outcome may report a failed act — that is what taught the competence hit').toBe( false )
+  })
+
+  it('still go out when nothing has changed', async () => {
+    // Without this the fix is a mute button. Same setup, no intervening turn.
+    const sent: string[][] = []
+    const s = freshState()
+    const exec = executor( sent )
+    reachOut( s, 'intent-1')
+
+    await run( s, exec, 6 )
+
+    expect( sent.length, 'a mind with something to say and no reason to hold it must speak').toBe( 1 )
+    expect( sent[0] ).toHaveLength( 2 )
+  })
+
+  it('still go out when the only turn predates the composition', async () => {
+    // Having spoken to them BEFORE composing is the ordinary case — it is
+    // usually what prompted the outreach in the first place.
+    const sent: string[][] = []
+    const s = freshState()
+    spokeTo( s, 'ke:fabrice', 0 )
+    const exec = executor( sent )
+    reachOut( s, 'intent-1')
+
+    await run( s, exec, 6 )
+    expect( sent.length ).toBe( 1 )
+  })
+
+  it('are unaffected by a conversation with somebody else', async () => {
+    const sent: string[][] = []
+    const s = freshState()
+    const exec = executor( sent )
+    reachOut( s, 'intent-1')
+
+    await run( s, exec, 6, t => { if( t === 2 ) spokeTo( s, 'ke:fkem', 2 ) })
+    expect( sent.length, 'talking to one person must not mute the mind toward another').toBe( 1 )
+  })
+})

--- a/tests/unit/agency.the-moment-passed.test.ts
+++ b/tests/unit/agency.the-moment-passed.test.ts
@@ -1,0 +1,84 @@
+// ─────────────────────────────────────────────────────────────
+// tests/unit/agency.the-moment-passed.test.ts
+// ─────────────────────────────────────────────────────────────
+/**
+ * Is this still what I want to say?
+ *
+ * Satiation gates SELECTION — whether to commit to speaking. It cannot touch
+ * words already selected and out for authoring. Authoring is off-tick and takes
+ * 10–30s of real time, and in that window the situation the words were composed
+ * for can move. Nothing looked at the door.
+ *
+ * Live, twice:
+ *
+ *   Fabrice: "I need my full attention on that right now. Will brief you later."
+ *   Lora:    "Understood. I'm here when you're ready."          ← correct
+ *   [41s]    "…here's where I am on the operational picture…"   ← composed before
+ *            "To turn it into something useful I need a brain-dump from you"
+ *            "Dump it rough. I'll structure it."
+ *
+ *   FKEM:    "I'm planning to go get some sleep now. You should too"
+ *   Lora:    "Night. Talk soon."                                ← correct
+ *   [1s]     "FKEM — late here too. 3 AM and I'm in that quiet window…"
+ *
+ * In both, the mind answered the new situation correctly and then delivered an
+ * older composition on top of its own answer. An act decided in one situation
+ * and performed in another is not the act that was decided on.
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { ReadonlySimulationState } from '#core/types'
+import { situationMoved } from '#agency/engines/motor.schema.executor'
+
+function state( sent: Array<{ target: string; tick: number }> ): ReadonlySimulationState {
+  const entities = new Map<string, unknown>()
+  sent.forEach( ( s, i ) => entities.set( `conversation-sent-${ i }`, {
+    id: `conversation-sent-${ i }`, type: 'conversation.sent',
+    createdAt: 0, updatedAt: 0,
+    metadata: { targetEntityId: s.target, tick: s.tick },
+  }) )
+  return { tick: 100, time: 0, entities, metrics: new Map() } as unknown as ReadonlySimulationState
+}
+
+describe('words composed for a moment that has passed', () => {
+  it('are withheld when the mind has spoken to them since composing', () => {
+    // The exact live sequence: words requested at 50, a reply delivered at 60,
+    // the composition landing after.
+    const moved = situationMoved( state([ { target: 'ke:fabrice', tick: 60 } ]), 'ke:fabrice', 50 )
+    expect( moved, 'the stale composition went out on top of the mind\'s own answer').not.toBeNull()
+    expect( moved ).toMatch( /already spoken to them since composing/ )
+  })
+
+  it('go out when nothing has happened since', () => {
+    expect( situationMoved( state([]), 'ke:fabrice', 50 ) ).toBeNull()
+  })
+
+  it('go out when the only thing said to them predates the composition', () => {
+    // Speaking BEFORE composing is the ordinary case — it is what prompted the
+    // outreach. Only a turn after the words were formed makes them stale.
+    expect( situationMoved( state([ { target: 'ke:fabrice', tick: 40 } ]), 'ke:fabrice', 50 ) ).toBeNull()
+  })
+
+  it('are not held hostage by a conversation with someone else', () => {
+    expect( situationMoved( state([ { target: 'ke:fkem', tick: 90 } ]), 'ke:fabrice', 50 ) ).toBeNull()
+  })
+
+  it('go out when nothing is known about when they were formed', () => {
+    // No `composedAt` ⇒ they never came through `_requestAuthoring`. Withholding
+    // on absent evidence would mute a mind for a reason it could not name, so
+    // the default is to speak.
+    expect( situationMoved( state([ { target: 'ke:fabrice', tick: 90 } ]), 'ke:fabrice', undefined ) ).toBeNull()
+  })
+
+  it('go out when there is nobody in particular to be stale toward', () => {
+    expect( situationMoved( state([ { target: 'ke:fabrice', tick: 90 } ]), undefined, 50 ) ).toBeNull()
+  })
+
+  it('names what changed, in the mind\'s own voice', () => {
+    // The withheld outcome records this verbatim, so the mind's history says why
+    // it did not speak rather than merely that it didn't.
+    const moved = situationMoved( state([ { target: 'ke:fabrice', tick: 60 } ]), 'ke:fabrice', 50 )!
+    expect( moved ).toMatch( /^I / )
+    expect( moved.endsWith('.') ).toBe( true )
+  })
+})


### PR DESCRIPTION
Satiation gates **selection** — whether to commit to speaking. It cannot touch words already selected and out for authoring. Authoring is off-tick and takes 10–30s of real time, and in that window the situation the words were composed for can move. Nothing looked.

## What it did to real people, twice

```
Fabrice: "I need my full attention on that right now. Will brief you later."
Lora:    "Understood. I'm here when you're ready."            ← correct
[41s]    "…here's where I am on the operational picture…"     ← composed before
         "To turn it into something useful I need a brain-dump from you"
         "Dump it rough. I'll structure it."
```

```
FKEM:    "I'm planning to go get some sleep now. You should too"
Lora:    "Night. Talk soon."                                  ← correct
[1s]     "FKEM — late here too. 3 AM and I'm in that quiet window…"
```

In both, the mind answered the new situation **correctly** and then delivered an older composition on top of its own answer. An act decided in one situation and performed in another is not the act that was decided on.

## The check

`situationMoved` is consulted at delivery and reads `conversation.sent` — the durable record of having spoken, written by every path that speaks (ProactiveCommunicator, the audition facet, the outbox). If the mind has said something to this person **since these words were asked for**, they are not its current words to them: it has already responded to whatever moved in between.

Deliberately **not** "did they speak since". `conversation.received` is a one-shot entity swept on the tick it is scanned, so there is nothing durable to look back at — and a signal that cannot be read at delivery time is a cog that ships dark, which is this codebase's recurring failure. In practice the two coincide: both incidents had the mind reply first and then deliver on top of its own answer.

## Withheld, not failed

Reuses #123's path exactly. The intent is freed and nothing is taught, so `reach-out` takes no competence hit for a judgement — the mistake #123 was written to fix and this must not reintroduce. `_withheld` now carries the mind's own account of what changed, so the outcome records *why* it did not speak rather than merely that it didn't:

> *"I had already spoken to them since composing this, so it was no longer what I had to say."*

## Scope is narrow on purpose

- **Only facet-composed words.** Content supplied upstream (`parameters.content`) came from the host with the present situation in hand.
- **Replies are untouched** — they never reach this path; the audition facet delivers them through the outbox. A rule that withheld words because the other person just spoke would mute every reply ever written.
- **A missing `composedAt` speaks rather than holds.** Withholding on absent evidence would mute a mind for a reason it could not name.

## Tests

`tests/unit/agency.the-moment-passed.test.ts` (7) — the predicate: stale, fresh, predating turn, a different person, unknown composition time, no addressee.
`tests/integration/agency.stale-words-stay-unsaid.test.ts` (5) — the real executor: the live Fabrice sequence is not delivered and resolves as withheld with no failed outcome, and fresh words still go out (without which the fix is a mute button).

Full suite: 218 files, 1734 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)