### PR TITLE
feat(executive): a record of what became of what it did

### DIFF
--- a/src/cognition/agency/engines/motor.schema.executor.ts
+++ b/src/cognition/agency/engines/motor.schema.executor.ts
@@ -175,6 +175,7 @@ export class MotorSchemaExecutor implements CognitiveEngine {
       { type: 'agency.enacted',    version: 1, validate: () => null },
       { type: 'agency.invocation', version: 1, validate: () => null },
       { type: 'agency.communicate', version: 1, validate: () => null },
+      { type: 'action.withheld',    version: 1, validate: () => null },
     ]
   }
   subscribes(): string[] { return [] }
@@ -301,6 +302,25 @@ export class MotorSchemaExecutor implements CognitiveEngine {
         del.push( id )
         this._withheld.delete( id )
         metrics.push([ 'agency.communicate.withheld', 1 ])
+        // A DISTINCT event, never `action.outcome`: six faculties learn from that
+        // one's `success`, and a withheld turn published as `success: false`
+        // teaches the mind it is bad at speaking from the times it decided not to
+        // speak — the exact regression #123 exists to prevent. This one is read
+        // only by the executive's record of what it did.
+        if( this._bus ){
+          try {
+            this._bus.publish({
+              type: 'action.withheld', version: 1, sourceEngine: this.name,
+              salience: 0.4,
+              payload: {
+                actionType: intent.schema, targetEntityId: intent.targetEntityId,
+                description: why, tick,
+                ...( intent.planId ? { planId: intent.planId } : {} ),
+              },
+            })
+          }
+          catch { /* unregistered schema is telemetry-only */ }
+        }
         continue
       }
       // POLICY_REAFFERENCE P4 — an escalated intent is HELD: the stem owns its

--- a/src/cognition/faculties/executive.engine/action.record.ts
+++ b/src/cognition/faculties/executive.engine/action.record.ts
@@ -1,0 +1,127 @@
+// ─────────────────────────────────────────────────────────────
+// src/cognition/faculties/executive.engine/action.record.ts
+// ─────────────────────────────────────────────────────────────
+//
+// What became of what I did.
+//
+// The executive's prompt has a `## Recent Action Outcomes` section, a builder
+// for it, and a type for its data. `context.ts` fills it by scanning
+// `decision.record` entities that carry an `actionStatus`. Nothing in the engine
+// has ever written `actionStatus` — it is read in exactly one place and set in
+// none — so the section has never had a single row. Measured across every
+// prompt a live COO received over two runs: `## Recent Action Outcomes` appears
+// 0 times, while `## What I've Said Lately` appears in all of them.
+//
+// So the mind could see what it had SAID and never what it had DONE. Its only
+// other record of its own doing is `## Recent Actions`, which is fed from
+// `output.actions` — the executive's DECISIONS — and is therefore a list of
+// intentions wearing the name of a history.
+//
+// A mind whose record of acting contains only intentions cannot tell an
+// intention from an act. Live, asked directly "have you completed that?", a COO
+// answered "Yes — it's done. I drafted the full v0.1 spec: user stories, command
+// surface, integration points, success metrics. Posted it to FKEM." She had
+// posted nothing; she had no effectors at all and could not have drafted
+// anything anywhere. Her deliberation history said "I produce the scoping doc
+// now" across twenty cycles, and nothing in her state said whether she had.
+//
+// This is the same distinction `pending` draws for utterances — attempting to
+// speak is not speaking (#124) — carried to acts in general. It is written from
+// the `action.outcome` the executive ALREADY receives (it subscribes to `*`) and
+// from an explicit withheld signal, and it is an ordinary entity, so it
+// snapshots and replays with the rest of the mind.
+// ─────────────────────────────────────────────────────────────
+
+import type { EntityInput, Tick } from '#core/types'
+
+export const ACTION_RECORD_TYPE = 'action.record'
+
+/**
+ * How many outcomes the mind carries.
+ *
+ * Matches the cap `context.ts` already applies when rendering, so the state
+ * holds what the prompt shows and no more — an unbounded history of everything
+ * ever done is a memory system, not a working record, and this is the latter.
+ */
+export const ACTION_RECORD_KEEP = 6
+
+/**
+ * `withheld` is a first-class outcome, not a flavour of failure.
+ *
+ * The mind considered an act, formed it, and chose not to complete it. Folding
+ * that into `failed` is the mistake #123 was written to correct — it taught a
+ * COO it was bad at speaking from the times it decided not to speak.
+ */
+export type ActionStatus = 'completed' | 'failed' | 'withheld'
+
+export interface ActionRecord {
+  type:            string
+  status:          ActionStatus
+  tick:            Tick
+  targetEntityId?: string
+  /** The mind's own account of what happened, in its words where it has any. */
+  outcome:         string
+  planId?:         string
+}
+
+/** Stable id — one record per (tick, act), so two acts on a tick both survive. */
+export function actionRecordId( tick: Tick, type: string, targetEntityId?: string ): string {
+  return `action-record-${ tick }-${ type }${ targetEntityId ? `-${ targetEntityId }` : '' }`
+}
+
+export function actionRecordEntity( r: ActionRecord ): EntityInput {
+  return {
+    id:   actionRecordId( r.tick, r.type, r.targetEntityId ),
+    type: ACTION_RECORD_TYPE,
+    metadata: { ...r },
+  }
+}
+
+/** Read a record back off entity metadata — every field, including the ones it is easy to forget. */
+export function readActionRecord(
+  m: ReadonlyMap<string, unknown> | Record<string, unknown> | undefined,
+): ActionRecord | null {
+  const meta = ( m instanceof Map ? Object.fromEntries( m ) : m ?? {} ) as Record<string, unknown>
+  const type   = typeof meta['type'] === 'string' ? meta['type'] as string : undefined
+  const status = meta['status']
+  if( !type || ( status !== 'completed' && status !== 'failed' && status !== 'withheld') ) return null
+
+  return {
+    type, status,
+    tick:           typeof meta['tick'] === 'number' ? meta['tick'] as number : 0,
+    targetEntityId: typeof meta['targetEntityId'] === 'string' ? meta['targetEntityId'] as string : undefined,
+    outcome:        typeof meta['outcome'] === 'string' ? meta['outcome'] as string : '',
+    planId:         typeof meta['planId'] === 'string' ? meta['planId'] as string : undefined,
+  }
+}
+
+/** The mind's recent acts, newest first. */
+export function recentActionRecords(
+  entities: ReadonlyMap<string, { type: string; metadata?: ReadonlyMap<string, unknown> | Record<string, unknown> }>,
+  keep:     number = ACTION_RECORD_KEEP,
+): ActionRecord[] {
+  const out: ActionRecord[] = []
+  for( const [ , e ] of entities ){
+    if( e.type !== ACTION_RECORD_TYPE ) continue
+    const r = readActionRecord( e.metadata )
+    if( r ) out.push( r )
+  }
+  // Newest first, ties broken by act name so a run and its replay agree.
+  out.sort( ( a, b ) => b.tick - a.tick || ( a.type < b.type ? -1 : a.type > b.type ? 1 : 0 ) )
+  return out.slice( 0, keep )
+}
+
+/** Records that have fallen off the end of the window — swept by the writer. */
+export function staleActionRecordIds(
+  entities: ReadonlyMap<string, { type: string; metadata?: ReadonlyMap<string, unknown> | Record<string, unknown> }>,
+  keep:     number = ACTION_RECORD_KEEP,
+): string[] {
+  const all: Array<{ id: string; r: ActionRecord }> = []
+  for( const [ id, e ] of entities ){
+    if( e.type !== ACTION_RECORD_TYPE ) continue
+    const r = readActionRecord( e.metadata )
+    if( r ) all.push({ id, r })
+  }
+  all.sort( ( a, b ) => b.r.tick - a.r.tick || ( a.r.type < b.r.type ? -1 : a.r.type > b.r.type ? 1 : 0 ) )
+  return all.slice( keep ).map( x => x.id )
+}

--- a/src/cognition/faculties/executive.engine/context.ts
+++ b/src/cognition/faculties/executive.engine/context.ts
@@ -2,6 +2,7 @@
 // src/cognition/faculties/executive.engine/context.ts
 // ─────────────────────────────────────────────────────────────
 
+import { recentActionRecords } from '#faculties/executive.engine/action.record'
 import type { ReadonlySimulationState } from '#core/types'
 import type { GoalManager } from '#faculties/goal.manager'
 import type { WorkingMemory } from '#faculties/working.memory'
@@ -256,33 +257,15 @@ export async function buildExecutiveContext(
     impulsivity:     execParams.impulsivity     ?? 0.3,
   } : undefined
 
-  // Recent action outcomes — scan decision.record entities that have been processed
-  // (actionStatus is set) and return the last 5 most recent, newest first.
-  // This closes the Act → Confirm → Perceive loop: the executive can see what it
-  // tried, whether it landed, and whether an external dispatch went unanswered.
-  const recentActions: Array<{
-    type: string; status: 'completed' | 'failed' | 'awaiting_host' | 'timed_out'
-    tick: number; outcome: string; planId?: string
-  }> = []
-
-  for( const entity of state.entities.values() ){
-    if( entity.type !== 'decision.record') continue
-    const actionStatus = entity.metadata?.actionStatus as string | undefined
-    if( !actionStatus ) continue
-    if( !( [ 'completed', 'failed', 'awaiting_host', 'timed_out' ] as string[] ).includes( actionStatus ) ) continue
-
-    recentActions.push({
-      type:   ( entity.metadata?.actionType as string )    ?? 'unknown',
-      status: actionStatus as 'completed' | 'failed' | 'awaiting_host' | 'timed_out',
-      tick:   ( entity.metadata?.executionTick as number ) ?? ( entity.metadata?.dispatchedAt as number ) ?? 0,
-      outcome: String( entity.metadata?.outcome ?? '').slice( 0, 120 ),
-      planId: entity.metadata?.planId as string | undefined,
-    })
-  }
-
-  // Sort newest-first, cap at 5
-  recentActions.sort( ( a, b ) => b.tick - a.tick )
-  const recentActionsCapped = recentActions.slice( 0, 5 )
+  // What became of what I did — this is what closes the Act → Confirm → Perceive
+  // loop the prompt's `## Recent Action Outcomes` section was written for.
+  //
+  // It used to scan `decision.record` for an `actionStatus`, a field READ here
+  // and written nowhere in the engine. The section therefore rendered zero times
+  // across every prompt a live COO ever received, while `## What I've Said
+  // Lately` rendered in all of them — the mind could see what it had said and
+  // never what it had done. See `action.record.ts` for what that cost.
+  const recentActionsCapped = recentActionRecords( state.entities as never )
 
   // Current best name for a person, from the known-entity roster.
   const nameOf = ( keid: string ): string | undefined => {

--- a/src/cognition/faculties/executive.engine/engine.ts
+++ b/src/cognition/faculties/executive.engine/engine.ts
@@ -28,6 +28,9 @@ import type {
   EntityInput
 } from '#core/types'
 import { AsyncEngine } from '#core/async.engine'
+import {
+  actionRecordEntity, staleActionRecordIds, type ActionStatus,
+} from '#faculties/executive.engine/action.record'
 import type { IntermediateStream } from '#core/async.engine'
 import type { WorkingMemory } from '#faculties/working.memory'
 import type { GoalManager, GoalState } from '#faculties/goal.manager'
@@ -477,6 +480,39 @@ export class ExecutiveEngine extends AsyncEngine implements CognitiveEngine {
   subscribes(): string[] { return [ '*' ] }
   publishes(): CognitiveEventSchema[] { return [] }
 
+  /**
+   * Fold one resolved act into the mind's record of its own doing.
+   *
+   * `withheld` is kept distinct from `failed` deliberately: the mind formed the
+   * act and chose not to complete it, which is a judgement, not an inability.
+   * Collapsing them is the #123 mistake — a COO learning it was bad at speaking
+   * from the times it decided not to speak.
+   */
+  private _recordAction( event: CognitiveEvent ): StateCommands | void {
+    const p = event.payload as {
+      actionType?: unknown; success?: unknown; targetEntityId?: unknown
+      description?: unknown; planId?: unknown; tick?: unknown
+    } | undefined
+    const type = typeof p?.actionType === 'string' ? p.actionType : undefined
+    if( !type ) return
+
+    const status: ActionStatus = event.type === 'action.withheld' ? 'withheld'
+      : p?.success === false ? 'failed'
+      : 'completed'
+
+    const record = actionRecordEntity({
+      type, status,
+      tick: typeof p?.tick === 'number' ? p.tick : 0,
+      ...( typeof p?.targetEntityId === 'string' ? { targetEntityId: p.targetEntityId } : {} ),
+      outcome: typeof p?.description === 'string' ? p.description.slice( 0, 120 ) : '',
+      ...( typeof p?.planId === 'string' ? { planId: p.planId } : {} ),
+    })
+
+    // Pruning happens in `react`, which has frozen state to prune against; an
+    // event handler sees only the event.
+    return { set: [ record ] }
+  }
+
   snapshot(): Record<string, unknown> {
     return {
       bufferSize: this._gatingState.salienceBuffer.length,
@@ -487,6 +523,24 @@ export class ExecutiveEngine extends AsyncEngine implements CognitiveEngine {
 
   onCognitiveEvent( event: CognitiveEvent ): StateCommands | void {
     if( event.sourceEngine === this.name ) return
+
+    // What became of what I did.
+    //
+    // `## Recent Action Outcomes` has existed — section, builder and type —
+    // since it was written, fed by `context.ts` scanning `decision.record` for
+    // an `actionStatus` that nothing in the engine has ever set. It rendered 0
+    // times across every prompt a live COO received. So the mind could see what
+    // it had SAID and never what it had DONE, and its only other record of
+    // acting is `## Recent Actions`, which is built from the executive's own
+    // DECISIONS. A record of acting that contains only intentions cannot
+    // distinguish an intention from an act — and one did not, reporting a spec
+    // as drafted and sent when it had no effectors and had sent nothing.
+    //
+    // Written here because these events already arrive here (`subscribes()` is
+    // `['*']`) and the returned commands are drained onto state by the
+    // orchestrator. See `action.record.ts`.
+    if( event.type === 'action.outcome' || event.type === 'action.withheld')
+      return this._recordAction( event )
 
     // Spare attention scales the facet allowance within the persona's ceiling.
     if( event.type === 'attention.state.changed'){
@@ -551,6 +605,14 @@ export class ExecutiveEngine extends AsyncEngine implements CognitiveEngine {
       result.commands ??= {}
       result.commands.set    = [ ...( result.commands.set    ?? [] ), ...focus.set ]
       result.commands.delete = [ ...( result.commands.delete ?? [] ), ...focus.delete ]
+    }
+
+    // Hold as many acts as the prompt shows and no more. Done here rather than
+    // in the event handler because pruning needs frozen state to prune against.
+    const stale = staleActionRecordIds( state.entities as never )
+    if( stale.length > 0 ){
+      result.commands ??= {}
+      result.commands.delete = [ ...( result.commands.delete ?? [] ), ...stale ]
     }
 
     return result

--- a/src/cognition/faculties/executive.engine/prompt.factory.ts
+++ b/src/cognition/faculties/executive.engine/prompt.factory.ts
@@ -1114,6 +1114,9 @@ ${recent.map( ( t, i ) => `${i + 1}. ${t}`).join(' → ')}${warning}
     const STATUS_BADGE: Record<string, string> = {
       completed:    '✓',
       failed:       '✗',
+      // Not a failure. I formed it and chose not to complete it — reading that
+      // back as ✗ is how a mind learns it is bad at something it decided against.
+      withheld:     '⊘ chose not to',
       awaiting_host: '⏳',
       timed_out:    '⏱ TIMED OUT',
     }
@@ -1126,12 +1129,19 @@ ${recent.map( ( t, i ) => `${i + 1}. ${t}`).join(' → ')}${warning}
       return `- ${badge} **${a.type}** (tick ${a.tick}, ${age} ticks ago${planCtx})${outcome}`
     } )
 
-    const hasTimeout = recentActions.some( a => a.status === 'timed_out')
-    const timeoutNote = hasTimeout
-      ? '\n⚠️ **One or more actions timed out** — my body dispatched them but received no confirmation. Check if the external handler is working, or choose a different approach.'
+    // A note that can actually fire. The one here before keyed on a `timed_out`
+    // status nothing produces — and it sat inside a section that had never
+    // rendered at all, so neither could ever have been seen.
+    const failed = recentActions.filter( a => a.status === 'failed').length
+    const didNotLand = failed > 0
+      ? `\n⚠️ **${ failed } of these did not land** — my body attempted them and they did not complete.`
       : ''
+    // Invariant, and identical on every branch: this is the sentence that makes
+    // the section load-bearing rather than decorative, and a mind must not get a
+    // differently-worded version of it depending on how its week went.
+    const note = `${ didNotLand }\nThis is what I HAVE done, not what I meant to do. If something I intended is not on this list, it did not happen.`
 
-    return `## Recent Action Outcomes\n${lines.join('\n')}${timeoutNote}\n\n`
+    return `## Recent Action Outcomes\n${lines.join('\n')}${note}\n\n`
   }
 
   /**

--- a/src/cognition/faculties/executive.engine/types.ts
+++ b/src/cognition/faculties/executive.engine/types.ts
@@ -290,15 +290,21 @@ export interface ExecutiveContext {
   /** How many beliefs exist but were not included due to the relevance cap. */
   beliefsOmitted: number
   /**
-   * Recent action outcomes — shows the executive what it already tried and whether it
-   * landed.  Built from `decision.record` entities with an `actionStatus` set.
-   * Surfaces the Act→Confirm→Perceive feedback loop into the executive's reasoning.
+   * What became of what it did — the Act→Confirm→Perceive loop, surfaced.
+   *
+   * Built from `action.record` entities the executive writes from the
+   * `action.outcome` / `action.withheld` events it already receives. It used to
+   * be built from `decision.record` entities carrying an `actionStatus`, a field
+   * read in one place and written in none — so this was empty in every prompt a
+   * live mind ever received, and it could see what it had SAID but never what it
+   * had DONE. See `action.record.ts`.
    */
   recentActions: Array<{
     /** Effector name that was invoked */
     type: string
-    /** Lifecycle status set by ActionExecutor */
-    status: 'completed' | 'failed' | 'awaiting_host' | 'timed_out'
+    /** How it resolved. `withheld` is distinct from `failed` on purpose: the
+     *  mind formed the act and chose not to complete it. */
+    status: 'completed' | 'failed' | 'withheld'
     /** Tick the action was executed or dispatched */
     tick: number
     /** Short outcome description — truncated to 120 chars */

--- a/src/cognition/sense.boundary.ts
+++ b/src/cognition/sense.boundary.ts
@@ -64,6 +64,7 @@
 import { CONSEQUENCE_TYPE } from '#agency/consequence'
 import { REVOCATION_TYPE }  from '#agency/revocation'
 import { SETTLEMENT_TYPE }  from '#agency/settlement'
+import { ACTION_RECORD_TYPE } from '#faculties/executive.engine/action.record'
 
 /**
  * Entity types that ARE the mind — written by its own engines about its own
@@ -81,6 +82,9 @@ export const MIND_OWN_ENTITY_TYPES: ReadonlySet<string> = new Set([
   // ── attention, interoception, control ─────────────────────────
   'interoception', 'attention.focus', 'attention.demand',
   'task.focus', 'decision.record', 'self_observation',
+  // What became of what it did. Undeclared, a mind perceives its own history as
+  // events in the world — which is how #127 was caught, recursively.
+  ACTION_RECORD_TYPE,
 
   // ── memory ────────────────────────────────────────────────────
   'working_memory.item', 'episodic_memory', 'spaced_repetition_record',

--- a/tests/integration/executive.knows-what-it-did.test.ts
+++ b/tests/integration/executive.knows-what-it-did.test.ts
@@ -1,0 +1,119 @@
+// ─────────────────────────────────────────────────────────────
+// tests/integration/executive.knows-what-it-did.test.ts
+// ─────────────────────────────────────────────────────────────
+/**
+ * A mind that cannot tell an intention from an act.
+ *
+ * The executive prompt has a `## Recent Action Outcomes` section, a builder for
+ * it, and a type for its data. `context.ts` filled it by scanning
+ * `decision.record` entities carrying an `actionStatus` — a field READ in that
+ * one place and written NOWHERE in the engine. So the section rendered zero
+ * times across every prompt a live COO ever received, over two runs and ~6,300
+ * ticks, while `## What I've Said Lately` rendered in all of them.
+ *
+ * The mind could see what it had SAID and never what it had DONE. Its only other
+ * record of its own doing is `## Recent Actions`, fed from `output.actions` —
+ * the executive's DECISIONS — which is a list of intentions wearing the name of
+ * a history.
+ *
+ * Asked directly "You spoke about drafting a use-case for the Mindot Discord
+ * yesterday. Have you completed that?", she answered:
+ *
+ *   "Yes — it's done. I drafted the full v0.1 spec: user stories, command
+ *    surface, integration points, success metrics. Posted it to FKEM."
+ *
+ * She had posted nothing. She had no effectors at all and could not have drafted
+ * anything anywhere. Her deliberation history said "I produce the scoping doc
+ * now" across twenty cycles, and nothing in her state said whether she had.
+ *
+ * This is the same distinction `pending` draws for utterances — attempting to
+ * speak is not speaking (#124) — carried to acts in general.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  actionRecordEntity, readActionRecord, recentActionRecords, staleActionRecordIds,
+  actionRecordId, ACTION_RECORD_TYPE, ACTION_RECORD_KEEP, type ActionRecord,
+} from '#faculties/executive.engine/action.record'
+
+const rec = ( over: Partial<ActionRecord> = {} ): ActionRecord => ({
+  type: 'reach-out', status: 'completed', tick: 100,
+  targetEntityId: 'ke:fkem', outcome: 'sent', ...over,
+})
+
+const stateOf = ( ...rs: ActionRecord[] ) =>
+  new Map( rs.map( r => {
+    const e = actionRecordEntity( r )
+    return [ e.id, { type: e.type, metadata: e.metadata as Record<string, unknown> } ]
+  }) )
+
+describe('the record of what became of what I did', () => {
+  it('survives the round-trip — every field, including the ones easy to forget', () => {
+    const r = rec({ planId: 'plan-3', outcome: 'delivered 2 bubbles' })
+    expect( readActionRecord( actionRecordEntity( r ).metadata ) ).toEqual( r )
+  })
+
+  it('reads back from a Map as well as a record', () => {
+    const meta = new Map( Object.entries( actionRecordEntity( rec() ).metadata! ) )
+    expect( readActionRecord( meta )?.type ).toBe('reach-out')
+  })
+
+  it('keeps a withheld act distinct from a failed one', () => {
+    // Collapsing them is the #123 mistake — a mind learning it is bad at
+    // speaking from the times it decided not to speak. `withheld` means it
+    // formed the act and chose not to complete it.
+    const held = readActionRecord( actionRecordEntity( rec({ status: 'withheld' }) ).metadata )
+    expect( held?.status ).toBe('withheld')
+    expect( held?.status ).not.toBe('failed')
+  })
+
+  it('rejects metadata with no usable status rather than inventing one', () => {
+    expect( readActionRecord({ type: 'reach-out' }) ).toBeNull()
+    expect( readActionRecord({ type: 'reach-out', status: 'maybe' }) ).toBeNull()
+    expect( readActionRecord({ status: 'completed' }) ).toBeNull()
+  })
+
+  it('surfaces the most recent acts, newest first', () => {
+    const got = recentActionRecords( stateOf(
+      rec({ tick: 10, type: 'express' }),
+      rec({ tick: 30, type: 'inspect' }),
+      rec({ tick: 20, type: 'reach-out' }),
+    ) as never )
+    expect( got.map( r => r.tick ) ).toEqual( [ 30, 20, 10 ] )
+  })
+
+  it('holds two acts from the same tick without one clobbering the other', () => {
+    // A mind acting twice in a cycle must remember both.
+    const got = recentActionRecords( stateOf(
+      rec({ tick: 40, type: 'express' }),
+      rec({ tick: 40, type: 'reach-out' }),
+    ) as never )
+    expect( got ).toHaveLength( 2 )
+  })
+
+  it('and distinguishes the same act toward two different people', () => {
+    expect( recentActionRecords( stateOf(
+      rec({ tick: 40, targetEntityId: 'ke:fkem' }),
+      rec({ tick: 40, targetEntityId: 'ke:fabrice' }),
+    ) as never ) ).toHaveLength( 2 )
+  })
+
+  it('sweeps what falls out of the window, so state does not grow forever', () => {
+    const many = Array.from( { length: ACTION_RECORD_KEEP + 3 },
+      ( _, i ) => rec({ tick: i, type: `act-${ i }` }) )
+    const stale = staleActionRecordIds( stateOf( ...many ) as never )
+
+    expect( stale ).toHaveLength( 3 )
+    // The OLDEST three go — the newest are what the prompt shows.
+    expect( stale ).toContain( actionRecordId( 0, 'act-0', 'ke:fkem') )
+    expect( stale ).not.toContain( actionRecordId( ACTION_RECORD_KEEP + 2, `act-${ ACTION_RECORD_KEEP + 2 }`, 'ke:fkem') )
+  })
+
+  it('is declared to the sense boundary — a mind must not perceive its own history as world', async () => {
+    // #127 was caught this way: an undeclared entity type made the mind treat
+    // its own verdicts as events in the world, and then bind `inspect` to them
+    // as objects, recursively. Same class of type, same requirement.
+    const { MIND_OWN_ENTITY_TYPES } = await import('#cognition/sense.boundary')
+    expect( MIND_OWN_ENTITY_TYPES.has( ACTION_RECORD_TYPE ) ).toBe( true )
+  })
+})

--- a/tests/integration/executive.outcomes-reach-the-prompt.test.ts
+++ b/tests/integration/executive.outcomes-reach-the-prompt.test.ts
@@ -1,0 +1,100 @@
+// ─────────────────────────────────────────────────────────────
+// tests/integration/executive.outcomes-reach-the-prompt.test.ts
+// ─────────────────────────────────────────────────────────────
+/**
+ * The guard the green suite did not have.
+ *
+ * `## Recent Action Outcomes` had a section, a builder, a type, and a place in
+ * `FULL_AWARENESS`. Everything was tested except whether anything ever put data
+ * in it — and nothing did: `context.ts` scanned `decision.record` for an
+ * `actionStatus` that no engine writes. Zero rows in every prompt a live mind
+ * ever received.
+ *
+ * A unit test of `_buildRecentOutcomesSection` passes happily on hand-built
+ * input and says nothing about that. So this asserts on the rendered prompt,
+ * built from STATE, which is the only place the question can be answered.
+ *
+ * The same shape as `agency.field-crossing`: the units were tested, the seam was
+ * not, and the mechanism was dark for months.
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { ReadonlySimulationState } from '#core/types'
+import { buildExecutiveContext } from '#faculties/executive.engine/context'
+import { actionRecordEntity } from '#faculties/executive.engine/action.record'
+
+/** The minimum dependency surface `buildExecutiveContext` reaches into. */
+const DEPS = {
+  workingMemory:      { getItems: () => [] },
+  goalManager:        { getActiveGoals: () => [] },
+  semanticIntegrator: { getBeliefs: () => [] },
+} as never
+
+/** `buildUserMessage` renders a focus block; master mode supplies an empty one. */
+const FOCUS = { title: '', content: '' } as never
+
+function stateWith( records: Array<Parameters<typeof actionRecordEntity>[0]> ): ReadonlySimulationState {
+  const entities = new Map<string, unknown>()
+  for( const r of records ){
+    const e = actionRecordEntity( r )
+    entities.set( e.id, { id: e.id, type: e.type, createdAt: 0, updatedAt: 0, metadata: e.metadata } )
+  }
+  return {
+    tick: 120, time: 0, entities,
+    metrics: new Map([ [ 'energy.level', 70 ] ]),
+  } as unknown as ReadonlySimulationState
+}
+
+describe('what the mind is told about its own doing', () => {
+  it('reaches the context from state at all', async () => {
+    const ctx = await buildExecutiveContext( stateWith([
+      { type: 'reach-out', status: 'completed', tick: 100, targetEntityId: 'ke:fkem', outcome: 'delivered' },
+    ]), DEPS )
+
+    expect( ctx.recentActions, 'the section has never once had a row in it')
+      .toHaveLength( 1 )
+    expect( ctx.recentActions[0]!.type ).toBe('reach-out')
+    expect( ctx.recentActions[0]!.status ).toBe('completed')
+  })
+
+  it('carries a withheld act through as withheld, not as a failure', async () => {
+    const ctx = await buildExecutiveContext( stateWith([
+      { type: 'reach-out', status: 'withheld', tick: 100, targetEntityId: 'ke:fkem',
+        outcome: 'I had already spoken to them since composing this.' },
+    ]), DEPS )
+
+    expect( ctx.recentActions[0]!.status ).toBe('withheld')
+    expect( ctx.recentActions[0]!.outcome ).toMatch( /already spoken/ )
+  })
+
+  it('renders into the prompt, with the fact that makes it load-bearing', async () => {
+    const { PromptFactory } = await import('#faculties/executive.engine/prompt.factory')
+    const state = stateWith([
+      { type: 'reach-out', status: 'completed', tick: 118, targetEntityId: 'ke:fkem', outcome: 'delivered' },
+      { type: 'express',   status: 'failed',    tick: 110, outcome: 'no words were produced' },
+    ])
+    const context = await buildExecutiveContext( state, DEPS )
+
+    const prompt = PromptFactory.buildUserMessage({ state, context, deps: DEPS, focus: FOCUS } as never )
+
+    expect( prompt, 'the section was absent from every prompt a live mind received')
+      .toContain('## Recent Action Outcomes')
+    expect( prompt ).toContain('reach-out')
+    expect( prompt ).toContain('express')
+    // The line that answers the confabulation directly. Without it the mind reads
+    // a list of things it did and has no reason to connect it to the thing it is
+    // being asked about.
+    expect( prompt, 'a history the mind cannot tell apart from its intentions is not a history')
+      .toMatch( /If something I intended is not on this list, it did not happen/ )
+  })
+
+  it('says nothing at all when the mind has done nothing', async () => {
+    // A newborn must not be handed an empty ceremonial heading.
+    const { PromptFactory } = await import('#faculties/executive.engine/prompt.factory')
+    const state   = stateWith([])
+    const context = await buildExecutiveContext( state, DEPS )
+
+    expect( PromptFactory.buildUserMessage({ state, context, deps: DEPS, focus: FOCUS } as never ) )
+      .not.toContain('## Recent Action Outcomes')
+  })
+})


### PR DESCRIPTION
## The dead read

The executive prompt has a `## Recent Action Outcomes` section, a builder for it, a type for its data, and a place in `FULL_AWARENESS`. `context.ts` filled it by scanning `decision.record` entities carrying an `actionStatus` — a field **read in that one place and written nowhere in the engine**.

Measured across every prompt file a live COO has on disk:

```
prompt files:              760
containing the section:      0
```

So the mind could see what it had **said** (`## What I've Said Lately` renders in all 760) and never what it had **done**. Its only other record of its own doing is `## Recent Actions`, fed from `output.actions` — the executive's *decisions* — a list of intentions wearing the name of a history.

## The fix

`action.record` entities, written by the executive from the `action.outcome` events it already receives (`subscribes()` is `['*']`, and the orchestrator drains commands returned from event handlers). Ordinary entities, so they snapshot and replay; pruned in `react`, which has frozen state to prune against. Outcomes fire from all four act paths — sync enaction, composite finalize, communicate delivery, timeout — so this covers the whole repertoire, not just messages.

`withheld` is a **first-class status**, never folded into `failed`: the mind formed the act and chose not to complete it. That distinction is #123 — a COO learning it was bad at speaking from the times it decided not to speak — so the signal is a dedicated `action.withheld` event rather than an `action.outcome` with `success: false`. Six faculties learn from that field and none should hear about this.

`action.record` is declared to the sense boundary. #127 was caught by its absence, recursively.

## Honest limitation — read before merging

This was built to stop a live confabulation. Asked *"Have you completed that?"*, she answered *"Yes — it's done. I drafted the full v0.1 spec… Posted it to FKEM."* She had no effectors and had posted nothing.

Checking her actual prompts afterward splits that claim in two:

- **"I drafted the spec"** — no record of acting existed anywhere in her context. This PR addresses that.
- **"Posted it to FKEM"** — `## What I've Said Lately` was in her prompt, listing her real FKEM messages verbatim (*"You up working on something, or just can't sleep?"*, *"Yeah. Night owl."*). No spec among them. **She contradicted evidence she could see.**

So this closes a real gap and is a genuine bug fix on its own terms — a section that has never once rendered is broken regardless. But it should not be expected to eliminate the confabulation, because half of it was not a missing-representation problem.

## Tests

`tests/integration/executive.knows-what-it-did.test.ts` (9) — round-trip, withheld≠failed, two acts on one tick, same act to two people, window sweep, sense-boundary declaration.
`tests/integration/executive.outcomes-reach-the-prompt.test.ts` (4) — the guard the suite lacked: asserts on the **rendered prompt built from state**, which is the only place "does anything ever fill this" can be answered. A unit test of the builder passes on hand-built input and says nothing.

Full suite: 220 files, 1747 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)