### PR TITLE
fix(agency): whoever moved the situation, it moved

### DIFF
--- a/src/cognition/agency/conversation.aim.ts
+++ b/src/cognition/agency/conversation.aim.ts
@@ -187,6 +187,38 @@ export function lastHeardByEntity( entities: ReadonlyMap<string, EntityLike> ): 
 /** When someone last spoke to us, AND what they said. */
 export interface Heard { tick: Tick; preview: string }
 
+/**
+ * When each person last spoke to the mind — the DURABLE version.
+ *
+ * `lastHeardByEntity` reads `conversation.received`, which lives exactly one
+ * tick: SocialPerception sweeps it as a one-shot event. So it answers "did
+ * someone speak to me THIS tick", never "when did they last speak to me".
+ *
+ * `answeredAt` is the durable half of the same fact, folded onto the mind's own
+ * `conversation.sent` turns by `resolveReplyExpectations` — it is what renders
+ * "they answered" in the prompt, and it survives snapshots.
+ *
+ * Written for the delivery-time re-check (`situationMoved`). That check first
+ * shipped keyed only on the mind having SPOKEN since composing, on the argument
+ * that nothing durable recorded the other direction. That was wrong — this is
+ * it — and the gap was the common case: live, a COO delivered a pre-composed
+ * agenda message two seconds after the person changed the subject, having said
+ * nothing in between, so the stale words arrived BEFORE her real reply and
+ * nothing was looking.
+ */
+export function lastAnsweredByEntity( entities: ReadonlyMap<string, EntityLike> ): Map<string, Tick> {
+  const out = new Map<string, Tick>()
+  for( const [ , e ] of entities ){
+    if( e.type !== SENT_TYPE ) continue
+    const m      = meta( e )
+    const target = str( m['targetEntityId'] )
+    const at     = num( m['answeredAt'] )
+    if( !target || at === undefined ) continue
+    if( at > ( out.get( target ) ?? -Infinity ) ) out.set( target, at as Tick )
+  }
+  return out
+}
+
 /** A turn still in the air: said, not acknowledged-only, and not yet answered. */
 export function isOpen( t: SpokenTurn ): boolean {
   return !t.isAck && t.answeredAt === undefined

--- a/src/cognition/agency/engines/motor.schema.executor.ts
+++ b/src/cognition/agency/engines/motor.schema.executor.ts
@@ -40,6 +40,7 @@ import { INNATE_SCHEMAS } from '#agency/schemas/innate'
 import { enact, type Enaction } from '#agency/execution.primitives'
 import { revokedIntentIds, revocationId, staleRevocationIds } from '#agency/revocation'
 import { addressesOf } from '#cognition/social.identity'
+import { lastAnsweredByEntity } from '#agency/conversation.aim'
 import {
   CONSEQUENCE_TYPE, CONSEQUENCE_TTL_TICKS,
   consequenceEntity, fnv1a, paramsKey, spokenAtByEntity } from '#agency/consequence'
@@ -954,12 +955,18 @@ function errMsg( err: unknown ): string {
  * responded to whatever moved in between, and this is an older turn arriving on
  * top of a newer one.
  *
- * Deliberately not "did they speak since" — `conversation.received` is a
- * one-shot entity swept on the tick it is scanned, so there is nothing durable
- * to look back at, and a signal that cannot be read at delivery time is a cog
- * that ships dark. In practice the two coincide: both live incidents this fixes
- * had the mind reply first ("Understood. I'm here when you're ready.", "Night.
- * Talk soon.") and then deliver the stale composition on top of its own answer.
+ * And `answeredAt` — when they last spoke to ME. This arm was missing at first,
+ * excluded on the argument that `conversation.received` is a one-shot entity
+ * swept on the tick it is scanned so nothing durable records the other
+ * direction. That was wrong: `answeredAt` is the durable half, folded onto the
+ * mind's own sent turns, and it is what renders "they answered" in the prompt.
+ *
+ * The gap was the COMMON case, not an edge. Live, a COO delivered a pre-composed
+ * agenda message ("I need a list of what's actively in flight…") two seconds
+ * after the person changed the subject, having said nothing in between — so the
+ * stale words arrived BEFORE her real reply and the spoken-since arm had not
+ * fired yet. The two signals were assumed to coincide and do not: whoever moved
+ * the situation, it moved.
  *
  * A missing `composedAt` means the words were never requested through
  * `_requestAuthoring` — nothing is known about when they were formed, so nothing
@@ -972,7 +979,14 @@ export function situationMoved(
   composedAt:     Tick | undefined,
 ): string | null {
   if( composedAt === undefined || !targetEntityId ) return null
+
+  const heard = lastAnsweredByEntity( state.entities as never ).get( targetEntityId )
+  if( heard !== undefined && heard > composedAt )
+    return 'They said something after I composed this, so it is an answer to a moment that has passed.'
+
   const spoke = spokenAtByEntity( state.entities as never ).get( targetEntityId )
-  if( spoke === undefined || spoke <= composedAt ) return null
-  return 'I had already spoken to them since composing this, so it was no longer what I had to say.'
+  if( spoke !== undefined && spoke > composedAt )
+    return 'I had already spoken to them since composing this, so it was no longer what I had to say.'
+
+  return null
 }

--- a/tests/unit/agency.the-moment-passed.test.ts
+++ b/tests/unit/agency.the-moment-passed.test.ts
@@ -30,12 +30,15 @@ import { describe, it, expect } from 'vitest'
 import type { ReadonlySimulationState } from '#core/types'
 import { situationMoved } from '#agency/engines/motor.schema.executor'
 
-function state( sent: Array<{ target: string; tick: number }> ): ReadonlySimulationState {
+function state( sent: Array<{ target: string; tick: number; answeredAt?: number }> ): ReadonlySimulationState {
   const entities = new Map<string, unknown>()
   sent.forEach( ( s, i ) => entities.set( `conversation-sent-${ i }`, {
     id: `conversation-sent-${ i }`, type: 'conversation.sent',
     createdAt: 0, updatedAt: 0,
-    metadata: { targetEntityId: s.target, tick: s.tick },
+    metadata: {
+      targetEntityId: s.target, tick: s.tick,
+      ...( s.answeredAt !== undefined ? { answeredAt: s.answeredAt } : {} ),
+    },
   }) )
   return { tick: 100, time: 0, entities, metrics: new Map() } as unknown as ReadonlySimulationState
 }
@@ -72,6 +75,45 @@ describe('words composed for a moment that has passed', () => {
 
   it('go out when there is nobody in particular to be stale toward', () => {
     expect( situationMoved( state([ { target: 'ke:fabrice', tick: 90 } ]), undefined, 50 ) ).toBeNull()
+  })
+
+  it('are withheld when THEY spoke since composing — even if the mind has not', () => {
+    // The gap the first cut missed, and it was the common case rather than an
+    // edge. Live: a COO delivered a pre-composed agenda message two seconds after
+    // the person changed the subject, having said nothing in between —
+    //
+    //   21:40:27  Fabrice: "I need some meeting with FKEM first"
+    //   21:40:29  Lora:    "Fabrice — I need a list of what's actively in flight…"
+    //   21:40:38  Lora:    "Sure. I'll be around."
+    //
+    // so the stale words arrived BEFORE her real reply and the spoken-since arm
+    // had not fired yet. Whoever moved the situation, it moved.
+    const moved = situationMoved(
+      state([ { target: 'ke:fabrice', tick: 20, answeredAt: 60 } ]), 'ke:fabrice', 50 )
+
+    expect( moved, 'they changed the subject and the pre-composed words went out anyway')
+      .not.toBeNull()
+    expect( moved ).toMatch( /said something after I composed this/ )
+  })
+
+  it('go out when their last word predates the composition', () => {
+    // Them having spoken BEFORE is the ordinary case — usually it is what
+    // prompted the outreach.
+    expect( situationMoved(
+      state([ { target: 'ke:fabrice', tick: 20, answeredAt: 40 } ]), 'ke:fabrice', 50 ) ).toBeNull()
+  })
+
+  it('is not confused by someone else answering', () => {
+    expect( situationMoved(
+      state([ { target: 'ke:fkem', tick: 20, answeredAt: 90 } ]), 'ke:fabrice', 50 ) ).toBeNull()
+  })
+
+  it('reports THEIR turn when both arms are live — it is the more recent truth', () => {
+    // Both fired: she spoke at 55, they spoke at 60. The account the mind records
+    // should be the one that actually left the words stranded.
+    expect( situationMoved(
+      state([ { target: 'ke:fabrice', tick: 55, answeredAt: 60 } ]), 'ke:fabrice', 50 ) )
+      .toMatch( /said something after I composed this/ )
   })
 
   it('names what changed, in the mind\'s own voice', () => {


### PR DESCRIPTION
#128 checks at delivery whether words a facet composed off-tick are still what the mind has to say. It shipped with **one arm** — *"have I spoken to them since composing"* — and explicitly excluded *"did they speak since"* on the argument that `conversation.received` is a one-shot entity swept on the tick it is scanned, so nothing durable records the other direction.

**That was wrong.** `answeredAt` is the durable half, folded onto the mind's own `conversation.sent` turns by `resolveReplyExpectations`. It is what already renders *"they answered: …"* in her prompt. It was one file away, in a module #128 already imported from.

## The gap was the common case

Measured on a live COO ten minutes after #128 merged:

```
21:40:27  Fabrice: "I need some meeting with FKEM first"
21:40:29  Lora:    "Fabrice — I need a list of what's actively in flight:
                    Will, Mindot Cloud, Ripplix, VLX…"        ← stale
21:40:38  Lora:    "Sure. I'll be around."                    ← the real reply
```

The message at `:29` is a pre-composed agenda item delivered **two seconds** after he changed the subject — far too fast to have been authored against it (her outreach median is ~15s). Because the stale words arrived *before* her real reply, the spoken-since arm had not fired yet and nothing was looking. **Zero withholds across the entire run**, in a conversation full of exactly the situation #128 exists to catch.

The two signals were assumed to coincide. They do not — and the ordering that breaks the assumption is the ordinary one.

## The change

Both arms, `answeredAt` first:

```ts
const heard = lastAnsweredByEntity( state.entities ).get( targetEntityId )
if( heard !== undefined && heard > composedAt )
  return 'They said something after I composed this, so it is an answer to a moment that has passed.'
```

`answeredAt` is checked first deliberately: when both are live it is the more recent truth and the one that actually stranded the words, so it is the account the mind records about its own silence.

`lastAnsweredByEntity` lives beside `lastHeardByEntity` in `conversation.aim.ts`, with the distinction between them documented — one answers *"did someone speak to me this tick"*, the other *"when did they last speak to me"*, and only the second can be read at delivery time.

## Tests

`tests/unit/agency.the-moment-passed.test.ts` — 4 new cases (11 total), including the live sequence above verbatim: they-spoke-since with the mind silent, their turn predating the composition, a different person answering, and both arms live at once.

Full suite: 220 files, 1751 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)