### PR TITLE
fix(tokens): cache rates are prices, and prices belong to the host

### DIFF
--- a/src/cognition/utilities/token.tracker.ts
+++ b/src/cognition/utilities/token.tracker.ts
@@ -77,9 +77,24 @@ export type LLMCallFunction =
 export type TokenLedgerRecord = Record<string, unknown>
 export type TokenRecordListener = ( record: TokenLedgerRecord ) => void
 
-// ── Prompt-cache pricing (Anthropic) ──────────────────────
+// ── Prompt-cache pricing ──────────────────────────────────
 // `input_tokens` in the API usage already EXCLUDES cached tokens, so the full
-// input cost is: fresh input ×1 + cache reads ×0.1 + cache writes ×1.25.
+// input cost is: fresh input ×1 + cache reads + cache writes.
+//
+// These two ratios are ANTHROPIC's, and they are the last prices this engine
+// ships. That is the inconsistency they encode: the module refuses to bake in
+// an input or output rate on the explicit grounds that "prices belong to the
+// host — they change on a vendor's schedule, differ per account, and are ~0 for
+// a self-hosted model", and then hardcodes two more prices because they happen
+// to be expressible as a ratio.
+//
+// They are wrong the moment a host is not on Anthropic. Z.ai charges $0.26/M
+// for cached input against $1.40/M fresh — a ratio of 0.186, not 0.10 — so a
+// COO's cache line came out 46% under. Its cache WRITES are free outright,
+// which 1.25 cannot express at all.
+//
+// So they are now a FALLBACK, used only when the host's `ModelPrice` does not
+// state the real rate. A host that says nothing gets exactly the old numbers.
 const CACHE_READ_MULT  = 0.1
 const CACHE_WRITE_MULT = 1.25
 
@@ -98,7 +113,21 @@ function normalizeModelKey( model: string ): string {
   return m.replace( /[-@]\d{6,8}$/, '')         // drop trailing -YYYYMMDD date stamp
 }
 /** USD per 1M tokens for one model. */
-export interface ModelPrice { input: number; output: number }
+export interface ModelPrice {
+  input:  number
+  output: number
+  /**
+   * USD per 1M cache-READ tokens. Absent ⇒ `input × 0.1` (Anthropic's ratio).
+   *
+   * State it whenever the host is not Anthropic. `0` is meaningful and honoured
+   * — some providers do not charge for cache reads at all — so this is read as
+   * "absent", not "falsy".
+   */
+  cachedInput?: number
+  /** USD per 1M cache-WRITE tokens. Absent ⇒ `input × 1.25`. `0` is honoured:
+   *  Z.ai's cache storage is free, which no multiple of input can express. */
+  cacheWrite?:  number
+}
 
 /**
  * Host-supplied prices, keyed by model id. Matching is exact first, then
@@ -334,8 +363,10 @@ export class TokenTracker implements SimulationEngine {
     const costUsd = pricing
       ? ( usage.promptTokens     / 1_000_000 ) * pricing.input  +
         ( usage.completionTokens / 1_000_000 ) * pricing.output +
-        ( cacheRead              / 1_000_000 ) * pricing.input * CACHE_READ_MULT  +
-        ( cacheWrite             / 1_000_000 ) * pricing.input * CACHE_WRITE_MULT
+        // `?? fallback` rather than `||`: a stated 0 is a real rate (free cache
+        // reads / free storage) and must not silently become the Anthropic ratio.
+        ( cacheRead              / 1_000_000 ) * ( pricing.cachedInput ?? pricing.input * CACHE_READ_MULT  ) +
+        ( cacheWrite             / 1_000_000 ) * ( pricing.cacheWrite  ?? pricing.input * CACHE_WRITE_MULT )
       : 0
 
     const full: TokenUsage = {

--- a/tests/unit/token.tracker.pricing.test.ts
+++ b/tests/unit/token.tracker.pricing.test.ts
@@ -94,11 +94,35 @@ describe('TokenTracker — cost accounting', () => {
     expect( t.totalCostUsd ).toBeCloseTo( 1.00, 6 )
   } )
 
-  it('prices cache reads at 0.1× input and cache writes at 1.25× input', () => {
+  it('falls back to 0.1× / 1.25× input when the host states no cache rate', () => {
     const t = priced()
     // Sonnet input $3/MTok: read 1M → $0.30, write 1M → $3.75
     t.recordUsage( usage( { model: 'claude-sonnet-4-5', cacheReadTokens: 1_000_000, cacheWriteTokens: 1_000_000 } ) )
     expect( t.totalCostUsd ).toBeCloseTo( 0.30 + 3.75, 6 )
+  } )
+
+  it('uses the host\'s stated cache rates over the Anthropic ratio', () => {
+    // The ratio is Anthropic's and is wrong off Anthropic. Z.ai charges $0.26/M
+    // cached against $1.40/M fresh — 0.186×, not 0.10× — which put a measured
+    // COO cache line 46% under.
+    const t = new TokenTracker({ prices: {
+      'glm-5.2': { input: 1.40, output: 4.40, cachedInput: 0.26, cacheWrite: 0 } } } as never )
+    t.recordUsage( usage( { model: 'glm-5.2', promptTokens: 0, completionTokens: 0,
+      cacheReadTokens: 1_000_000, cacheWriteTokens: 1_000_000 } ) )
+
+    expect( t.totalCostUsd, 'stated rates must win, and free storage must cost nothing')
+      .toBeCloseTo( 0.26, 6 )
+  } )
+
+  it('honours a stated rate of 0 rather than reading it as absent', () => {
+    // `?? fallback`, not `|| fallback`. Free cache reads are a real offer and
+    // must not silently become 0.1× input.
+    const t = new TokenTracker({ prices: {
+      'free-cache': { input: 10, output: 0, cachedInput: 0 } } } as never )
+    t.recordUsage( usage( { model: 'free-cache', promptTokens: 0, completionTokens: 0,
+      cacheReadTokens: 1_000_000 } ) )
+
+    expect( t.totalCostUsd ).toBe( 0 )
   } )
 
   it('prices embeddings as input-only at the embedding rate', () => {


### PR DESCRIPTION
`token.tracker.ts` refuses to ship an input or output rate, on the explicit grounds that:

> Prices belong to the host: they change on a vendor's schedule, differ per account, and are ~0 for a self-hosted model. The engine ships none.

And then hardcodes two more prices, because they happen to be expressible as a ratio of one it does not ship:

```ts
const CACHE_READ_MULT  = 0.1
const CACHE_WRITE_MULT = 1.25
```

## Why it matters now

Those ratios are Anthropic's. Measured against Z.ai's published rates:

| | Z.ai GLM-5.2 | ratio to input | engine assumed |
|---|---|---|---|
| input | $1.40 / M | — | — |
| cached input | $0.26 / M | **0.186×** | 0.10× |
| cache write | free | **0×** | 1.25× |

A live COO run came out **46% under on the cache line**, and free storage is a rate no multiple of input can express at all. Small in absolute terms today (~$0.04 on a $0.84 run) but wrong by construction, and it grows as cache hit rate improves — hers is already 49%.

## The change

`ModelPrice` gains optional `cachedInput` and `cacheWrite`. The ratios stay as the **fallback**, so a host that states nothing gets exactly the old numbers and no existing cost changes.

Read with `??`, not `||`: a stated `0` is a real rate — free cache reads and free storage are both real offers — and must not silently fall through to the Anthropic ratio.

## Tests

`tests/unit/token.tracker.pricing.test.ts` — the existing ratio test is retitled to say it is a *fallback*, plus two new: host-stated rates win over the ratio, and a stated `0` is honoured rather than read as absent.

Full suite: 220 files, 1753 passed, 2 skipped.

Host side (`executive/coo/lora.ts`, separate repo) now declares the real Z.ai table, so its ledger reports cost instead of `priced: false` on every row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)