### PR TITLE
fix(wire): a protocol marker is not something a mind can say

### DIFF
--- a/src/cognition/faculties/executive.engine/parser.ts
+++ b/src/cognition/faculties/executive.engine/parser.ts
@@ -3,7 +3,7 @@
 // ─────────────────────────────────────────────────────────────
 
 import { logger } from '#core/logger'
-import { REPLY_TEXT_TAG, NO_MESSAGE_TAG, NO_MESSAGE_OPEN } from '#llm/wire.contracts'
+import { REPLY_TEXT_TAG, NO_MESSAGE_TAG, NO_MESSAGE_OPEN, stripProtocolMarkers } from '#llm/wire.contracts'
 import type { ReadonlySimulationState } from '#core/types'
 import type { ExecutiveOutputFull, ExecutiveOutputMinimal, IdeationCandidate, IdeationOutput } from '#faculties/executive.engine/types'
 
@@ -339,7 +339,15 @@ function extractBlock( text: string, tag: string ): string | null {
  * Used for [REPLY_TEXT] — content is streamed directly to the client,
  * so it must be clean prose, not a JSON payload.
  */
-function extractTextBlock( text: string, tag: string ): string | null {
+/**
+ * Pull one plain-text block out of a response.
+ *
+ * Exported for the guard: this slice is where a stray marker survives into
+ * content, and the seam is the thing worth testing. `parseResponse` needs a full
+ * well-formed response around it, which is exactly the setup that hides a defect
+ * living in one line of string handling.
+ */
+export function extractTextBlock( text: string, tag: string ): string | null {
   const open  = `[${tag}]`
   const close = `[/${tag}]`
   const openIdx  = text.indexOf( open )
@@ -350,7 +358,12 @@ function extractTextBlock( text: string, tag: string ): string | null {
     ? text.slice( contentStart, closeIdx )
     : text.slice( contentStart )   // unclosed block — take everything after the open marker
 
-  return content.trim() || null
+  // A stray marker INSIDE the body survives this slice — the block runs from the
+  // first open to the first close after it, and anything between is content by
+  // construction. Live, a reply went out as four substantive bubbles and a fifth
+  // reading exactly `[REPLY_TEXT]`: the person received a message whose whole
+  // content was the name of the slot it should have filled.
+  return stripProtocolMarkers( content ) || null
 }
 
 /**

--- a/src/llm/wire.contracts.ts
+++ b/src/llm/wire.contracts.ts
@@ -58,6 +58,44 @@ export function wrapReplyText( body: string ): string {
   return [ REPLY_TEXT_OPEN, body, REPLY_TEXT_CLOSE ].join('\n')
 }
 
+/**
+ * Every marker that is PROTOCOL rather than content.
+ *
+ * Named explicitly rather than matched as `[ANYTHING]`, because bracketed text is
+ * ordinary in real messages — "[1]", "[see §4.4]", "[REDACTED]" are things a mind
+ * may legitimately say, and a greedy strip would eat them.
+ */
+export const PROTOCOL_TAGS: readonly string[] = [
+  REPLY_TEXT_TAG, NO_MESSAGE_TAG, 'INTROSPECTION', 'NARRATIVE', 'SELF_OBS',
+]
+
+/**
+ * Remove any protocol marker that survived inside extracted content.
+ *
+ * `extractTextBlock` slices from the first `[TAG]` to the first `[/TAG]` after
+ * it, so a STRAY second opener inside the body is carried out as content — and
+ * the bubble splitter, seeing a line of its own, delivers it as a message.
+ *
+ * Live: a COO's reply to a technical document went out as four substantive
+ * bubbles followed by a fifth reading exactly `[REPLY_TEXT]`. The person got a
+ * message whose entire content was the name of the slot it should have filled.
+ *
+ * These tokens can never be legitimate content — they are the wire, not the
+ * words — so stripping them is not censorship of anything the mind meant. A line
+ * left empty by the removal is dropped so it cannot become an empty bubble.
+ */
+export function stripProtocolMarkers( text: string ): string {
+  let out = text
+  for( const tag of PROTOCOL_TAGS )
+    out = out.split(`[${ tag }]`).join('').split(`[/${ tag }]`).join('')
+
+  return out
+    .split('\n')
+    .filter( ( line, i, all ) => line.trim() !== '' || ( i > 0 && i < all.length - 1 && all[ i - 1 ]?.trim() !== '') )
+    .join('\n')
+    .trim()
+}
+
 // ── Conversation-facet focus — render ↔ match pair ────────────
 // The AuditionEngine RENDERS these lines into the facet focus; the mock LLM
 // MATCHES them to detect "this call is a conversation turn" and synthesize a

--- a/tests/unit/wire.no-markers-in-the-message.test.ts
+++ b/tests/unit/wire.no-markers-in-the-message.test.ts
@@ -1,0 +1,83 @@
+// ─────────────────────────────────────────────────────────────
+// tests/unit/wire.no-markers-in-the-message.test.ts
+// ─────────────────────────────────────────────────────────────
+/**
+ * The wire is not the words.
+ *
+ * `extractTextBlock` slices from the first `[REPLY_TEXT]` to the first
+ * `[/REPLY_TEXT]` after it. Anything between is content BY CONSTRUCTION — so a
+ * stray second opener inside the body is carried out as content, and the bubble
+ * splitter, seeing it alone on a line, delivers it as a message.
+ *
+ * Live, a COO's reply to a technical document went out as four substantive
+ * bubbles and a fifth:
+ *
+ *   [outbox-writer] reply → discord:1019… bubble[3] "The simulation sandbox (§5.1)…"
+ *   [outbox-writer] reply → discord:1019… bubble[4] "[REPLY_TEXT]"
+ *   22:06:41  💬 → discord:1019…: [REPLY_TEXT]
+ *
+ * The person received a message whose entire content was the name of the slot it
+ * should have filled.
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  stripProtocolMarkers, wrapReplyText, PROTOCOL_TAGS,
+  REPLY_TEXT_OPEN, REPLY_TEXT_CLOSE,
+} from '#llm/wire.contracts'
+import { extractTextBlock } from '#faculties/executive.engine/parser'
+import { REPLY_TEXT_TAG } from '#llm/wire.contracts'
+
+/** What the parser does with a facet response: pull the reply block out of it. */
+const reply = ( body: string ): string | null =>
+  extractTextBlock( wrapReplyText( body ), REPLY_TEXT_TAG )
+
+describe('protocol markers never reach the room', () => {
+  it('strips a stray opener left inside the body — the live failure', () => {
+    const out = reply( [ 'The architecture diagram answers it.', '',
+      'The §9 sequence is the signal.', '', REPLY_TEXT_OPEN ].join('\n') )
+
+    expect( out ).not.toContain('[REPLY_TEXT]')
+    expect( out, 'the words themselves must survive intact')
+      .toContain('The architecture diagram answers it.')
+    expect( out ).toContain('The §9 sequence is the signal.')
+  })
+
+  it('leaves no empty trailing bubble where the marker was', () => {
+    // Removing the token is only half the job: a blank line alone still splits
+    // into a bubble, so the person gets an empty message instead of a literal one.
+    const out = reply(`Real words.\n\n${ REPLY_TEXT_OPEN }`)!
+    expect( out.split('\n\n').filter( b => b.trim() === '') ).toEqual( [] )
+    expect( out.endsWith('Real words.') ).toBe( true )
+  })
+
+  it('strips a stray CLOSER too — the same slip in the other direction', () => {
+    expect( reply(`Words.\n${ REPLY_TEXT_CLOSE }\nMore words.`) ).not.toContain('[/REPLY_TEXT]')
+  })
+
+  it('strips every protocol tag, not just the reply block', () => {
+    // A mind that emits a tagged block inside its reply leaks the tag the same way.
+    for( const tag of PROTOCOL_TAGS ){
+      expect( stripProtocolMarkers( `before [${ tag }] after` ) ).toBe('before  after')
+      expect( stripProtocolMarkers( `before [/${ tag }] after` ) ).toBe('before  after')
+    }
+  })
+
+  it('does NOT eat bracketed text a mind may legitimately write', () => {
+    // The reason this names its tags instead of matching `[ANYTHING]`. She cites
+    // spec sections constantly — "[see §4.4]" is a thing she actually says.
+    const kept = 'One thing I notice: the Deadline Watcher [see §4.4] catches [1] the absence [REDACTED].'
+    expect( stripProtocolMarkers( kept ) ).toBe( kept )
+  })
+
+  it('an ordinary reply is returned byte-identical', () => {
+    const body = 'Clear — VLX-Ledger ships without Ripplix. That unblocks the independent path.'
+    expect( reply( body ) ).toBe( body )
+  })
+
+  it('a body that was ONLY a marker yields no reply at all, rather than an empty one', () => {
+    // What should have happened live: nothing to say is silence, not a blank
+    // message and not the token.
+    expect( reply( REPLY_TEXT_OPEN ) ).toBeNull()
+  })
+})


### PR DESCRIPTION
## What the person received

```
[outbox-writer] reply → discord:1019… bubble[3] "The simulation sandbox (§5.1)…"
[outbox-writer] reply → discord:1019… bubble[4] "[REPLY_TEXT]"

22:06:41  💬 → discord:1019…: [REPLY_TEXT]
```

Four substantive bubbles reviewing a technical spec, then a fifth message whose entire content was **the name of the slot it should have filled**.

## Why

`extractTextBlock` slices from the first `[REPLY_TEXT]` to the first `[/REPLY_TEXT]` after it. Anything between them is content *by construction* — so a stray second opener inside the body is carried out as content, and the bubble splitter, seeing it alone on a line, delivers it as its own message.

## The fix

`stripProtocolMarkers` removes any protocol token that survived into extracted content, and drops the line it leaves behind — otherwise the blank still splits into a bubble and the person gets an *empty* message instead of a literal one.

It **names its tags** rather than matching `[ANYTHING]`:

```ts
export const PROTOCOL_TAGS = [ REPLY_TEXT_TAG, NO_MESSAGE_TAG, 'INTROSPECTION', 'NARRATIVE', 'SELF_OBS' ]
```

Bracketed text is ordinary in real messages. This mind cites spec sections constantly — `[see §4.4]` is a thing she actually wrote in the same conversation — and `[1]` and `[REDACTED]` are things any mind may legitimately say. A greedy strip would eat them, which is a worse failure than the one being fixed: silently editing what someone meant.

## Testing the seam, not the wrapper

`extractTextBlock` is now exported. The bug lives in one line of string handling, and reaching it through `parseResponse` requires a full well-formed response around it — exactly the setup that hides a defect this size. Same reasoning as `foldStreamUsage` and `situationMoved`.

`tests/unit/wire.no-markers-in-the-message.test.ts` (7): the live failure, stray closers, every protocol tag, an ordinary reply returned byte-identical, legitimate bracketed text preserved, and a body that was *only* a marker yielding silence rather than an empty message.

Full suite: 221 files, 1760 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)