### PR TITLE
fix(affect): tell the mind what it feels

### DIFF
--- a/src/cognition/faculties/affective.blender.ts
+++ b/src/cognition/faculties/affective.blender.ts
@@ -47,6 +47,21 @@ const ACP_CONFIDENCE     = 0.4
  * Numeric encoding for dominant emotion metric.
  * Consumers decode using DOMINANT_EMOTION_LABELS[code].
  */
+/**
+ * The entity carrying the non-numeric side of affect — what the mind is feeling,
+ * by name.
+ *
+ * Exported as a CONSTANT because the id is a contract between two files and it
+ * silently broke: `context.ts` read `state.entities.get('affective-state')`, an
+ * id nothing has ever written, so `dominantEmotion` fell back to 'neutral' in
+ * every prompt ever rendered. Measured live: a COO sitting at frustration 1.000
+ * and boredom 1.000 was told "Dominant emotion: neutral".
+ *
+ * Two string literals in two files cannot disagree if there is only one.
+ */
+export const AFFECT_STATE_ID   = 'affect-blends'
+export const AFFECT_STATE_TYPE = 'affect.blends'
+
 const DOMINANT_EMOTION_CODES: Record<string, number> = {
   'neutral':       0,
   'fear':          1,
@@ -381,11 +396,13 @@ export class AffectiveBlender implements SimulationEngine, CognitiveEngine {
     const dominantCode = DOMINANT_EMOTION_CODES[ dominant ?? 'neutral' ] ?? 0
     commands.metrics!.push([ 'affect.dominant_emotion', dominantCode ])
 
-    // Persist active blends as a state entity so the executive bridge can read them
+    // The mind's own read on what it is feeling, as an entity the executive can
+    // render. `dominantEmotion` is written as the LABEL, not the code: the code
+    // goes to metrics for telemetry, and a prompt cannot say "I feel 20".
     commands.set!.push({
-      id: 'affect-blends',
-      type:     'affect.blends',
-      metadata: { blends },
+      id:   AFFECT_STATE_ID,
+      type: AFFECT_STATE_TYPE,
+      metadata: { dominantEmotion: dominant ?? 'neutral', blends },
     })
 
     // 8. Track emotion history for blending detection

--- a/src/cognition/faculties/executive.engine/context.ts
+++ b/src/cognition/faculties/executive.engine/context.ts
@@ -3,6 +3,7 @@
 // ─────────────────────────────────────────────────────────────
 
 import { recentActionRecords } from '#faculties/executive.engine/action.record'
+import { AFFECT_STATE_ID } from '#faculties/affective.blender'
 import type { ReadonlySimulationState } from '#core/types'
 import type { GoalManager } from '#faculties/goal.manager'
 import type { WorkingMemory } from '#faculties/working.memory'
@@ -655,12 +656,14 @@ function extractAffect( state: ReadonlySimulationState ): ExecutiveContext['affe
   const arousal   = state.metrics.get('affect.arousal')   ?? 0.5
   const dominance = state.metrics.get('affect.dominance') ?? 0.5
 
-  // Non-numeric affect data — read from the affective-state entity.
-  // AffectiveBlender writes this entity each tick with dominantEmotion and blends.
+  // Non-numeric affect data — read from the entity AffectiveBlender writes each
+  // tick. The id comes from the writer rather than being spelled again here: this
+  // read used to look for 'affective-state', which nothing has ever written, so
+  // both values silently took their fallbacks in every prompt ever rendered.
   let dominantEmotion = 'neutral'
   let blends: string[] = []
 
-  const affectEntity = state.entities.get('affective-state')
+  const affectEntity = state.entities.get( AFFECT_STATE_ID )
   if( affectEntity ){
     dominantEmotion = (affectEntity.metadata?.dominantEmotion as string) ?? 'neutral'
     blends = (affectEntity.metadata?.blends as string[]) ?? []

--- a/tests/integration/affect.knows-what-it-feels.test.ts
+++ b/tests/integration/affect.knows-what-it-feels.test.ts
@@ -1,0 +1,113 @@
+// ─────────────────────────────────────────────────────────────
+// tests/integration/affect.knows-what-it-feels.test.ts
+// ─────────────────────────────────────────────────────────────
+/**
+ * Being told what you feel.
+ *
+ * `context.ts` read `state.entities.get('affective-state')` for the non-numeric
+ * side of affect. `AffectiveBlender` writes `affect-blends`. Nothing has ever
+ * written `affective-state` — it appears in exactly one place in the tree, the
+ * read — so `dominantEmotion` took its `?? 'neutral'` fallback in every prompt
+ * ever rendered. The blender also never put `dominantEmotion` on the entity at
+ * all; it went to the metrics map as a numeric code, and a prompt cannot say
+ * "I feel 20".
+ *
+ * Measured on a live COO at tick 10213:
+ *
+ *   frustration      1.000
+ *   boredom          1.000
+ *   irritability     0.667
+ *   ...
+ *   affect.dominant_emotion = 10   (frustration)
+ *
+ * and her prompt said: "Dominant emotion: neutral".
+ *
+ * A mind saturated on frustration and boredom, told it feels neutral, has no
+ * representation with which to act on either.
+ *
+ * The id is now a shared constant. Two string literals in two files cannot
+ * disagree if there is only one.
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { ReadonlySimulationState } from '#core/types'
+import { AFFECT_STATE_ID, AFFECT_STATE_TYPE } from '#faculties/affective.blender'
+import { buildExecutiveContext } from '#faculties/executive.engine/context'
+
+const DEPS = {
+  workingMemory:      { getItems: () => [] },
+  goalManager:        { getActiveGoals: () => [] },
+  semanticIntegrator: { getBeliefs: () => [] },
+} as never
+const FOCUS = { title: '', content: '' } as never
+
+function stateWith( metadata: Record<string, unknown> | null ): ReadonlySimulationState {
+  const entities = new Map<string, unknown>()
+  if( metadata )
+    entities.set( AFFECT_STATE_ID, {
+      id: AFFECT_STATE_ID, type: AFFECT_STATE_TYPE, createdAt: 0, updatedAt: 0, metadata })
+  return {
+    tick: 10213, time: 0, entities,
+    metrics: new Map<string, number>([
+      [ 'affect.valence', -0.099 ], [ 'affect.arousal', 0.365 ], [ 'affect.dominance', 0 ],
+      [ 'energy.level', 92 ],
+    ]),
+  } as unknown as ReadonlySimulationState
+}
+
+describe('what the mind is told it feels', () => {
+  it('reaches the context — the live frustration case', async () => {
+    const ctx = await buildExecutiveContext(
+      stateWith({ dominantEmotion: 'frustration', blends: [] }), DEPS )
+
+    expect( ctx.affect.dominantEmotion, 'it said "neutral" while saturated on frustration')
+      .toBe('frustration')
+  })
+
+  it('and reaches the PROMPT, which is the only place it matters', async () => {
+    const { PromptFactory } = await import('#faculties/executive.engine/prompt.factory')
+    const state   = stateWith({ dominantEmotion: 'frustration', blends: [] })
+    const context = await buildExecutiveContext( state, DEPS )
+    const prompt  = PromptFactory.buildUserMessage({ state, context, deps: DEPS, focus: FOCUS } as never )
+
+    expect( prompt ).toContain('Dominant emotion: frustration')
+    expect( prompt ).not.toContain('Dominant emotion: neutral')
+  })
+
+  it('carries blends through when the blender detects any', async () => {
+    const ctx = await buildExecutiveContext(
+      stateWith({ dominantEmotion: 'joy', blends: [ 'bittersweet' ] }), DEPS )
+    expect( ctx.affect.blends ).toEqual( [ 'bittersweet' ] )
+  })
+
+  it('still says neutral when there is genuinely nothing to report', async () => {
+    // The fallback is correct for a mind that has not felt anything yet — it was
+    // only wrong as the ALWAYS case.
+    const ctx = await buildExecutiveContext( stateWith( null ), DEPS )
+    expect( ctx.affect.dominantEmotion ).toBe('neutral')
+    expect( ctx.affect.blends ).toEqual( [] )
+  })
+
+  it('the numeric core still comes from metrics, unchanged', async () => {
+    const ctx = await buildExecutiveContext(
+      stateWith({ dominantEmotion: 'boredom', blends: [] }), DEPS )
+    expect( ctx.affect.valence ).toBeCloseTo( -0.099, 6 )
+    expect( ctx.affect.arousal ).toBeCloseTo( 0.365, 6 )
+  })
+})
+
+describe('the writer and the reader agree by construction', () => {
+  it('the blender writes the id the context reads', async () => {
+    // The whole defect in one assertion. Before this, the writer said
+    // 'affect-blends' and the reader said 'affective-state', and nothing failed.
+    const { AffectiveBlender } = await import('#faculties/affective.blender')
+    const blender = new AffectiveBlender()
+    const res = await blender.react( 0, 1 as never, stateWith( null ), {} as never )
+
+    const written = ( res.commands?.set ?? [] ).find( e => e.type === AFFECT_STATE_TYPE )
+    expect( written, 'the blender must write the affect entity every tick').toBeDefined()
+    expect( written!.id ).toBe( AFFECT_STATE_ID )
+    expect( written!.metadata, 'dominantEmotion was never on the entity — only the numeric code, in metrics')
+      .toHaveProperty('dominantEmotion')
+  })
+})


### PR DESCRIPTION
## The mismatch

```ts
// context.ts — the reader
const affectEntity = state.entities.get('affective-state')
dominantEmotion = affectEntity?.metadata?.dominantEmotion ?? 'neutral'

// affective.blender.ts — the writer
commands.set!.push({ id: 'affect-blends', type: 'affect.blends', metadata: { blends } })
```

`affective-state` appears in **exactly one place in the tree** — that read. Nothing has ever written it. So `dominantEmotion` took its `?? 'neutral'` fallback in every prompt ever rendered, and `blends` was always `[]`.

And even with the id fixed, the blender never put `dominantEmotion` on the entity at all. It went to the metrics map as a numeric code, and a prompt cannot say *"I feel 20"*.

## What it cost

Measured on a live COO at tick 10213:

```
frustration      1.000  ████████████████████████████████████
boredom          1.000  ████████████████████████████████████
irritability     0.667  ███████████████████████
trust            0.492  █████████████████
loneliness       0.375  █████████████

affect.dominant_emotion = 10   (frustration)
```

Her prompt said:

```
## How I Feel
Dominant emotion: neutral
```

A mind saturated on frustration and boredom, told it feels neutral, has no representation with which to act on either.

## The fix

The id is one exported constant both sides import, and the blender writes `dominantEmotion` as a **label**. Two string literals in two files cannot disagree if there is only one — which is the actual lesson here, because the type was right, the shape was right, the suite was green, and nothing failed.

`blends: []` is **not** part of this defect and is left alone: `_detectBlends` looks for named pairs (bittersweet, anxious_excitement…), and frustration+boredom is not one of them. Empty was the correct answer.

## Tests

`tests/integration/affect.knows-what-it-feels.test.ts` (6) — the live frustration case reaching the context, reaching the **rendered prompt**, blends carried through, `neutral` still correct when there is genuinely nothing to report, the numeric core unchanged, and — the whole defect in one assertion — the blender writing the id the context reads.

Full suite: 222 files, 1766 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)