### PR TITLE
docs(todo): `inbound_percept` is not a bypass — I was wrong

### DIFF
--- a/.TODO/SIGNAL_BOUNDARY.md
+++ b/.TODO/SIGNAL_BOUNDARY.md
@@ -1262,14 +1262,20 @@ one is bound, with the in-process call as the fallback.
       room with no name stays unnamed rather than labelled with its id.
 - [x] The backend states `'exafferent'` at the point where it knows.
 
-> **Still a bypass, and now the only one: `inbound_percept` → `injectEvent`.**
-> It writes a `senses.<domain>` ENTITY straight into state rather than routing
-> through `senseSignal`. Worth knowing before anyone fixes it: the consumers of
-> `senses.*` are bus EVENTS named `senses.<domain>.percept`, and `action.selector`
-> requires the `.percept` suffix — so what this channel injects is close to
-> inert. Fixing it properly means giving the envelope a real `SensoryInput`
-> shape (a `kind`, a provenance), which is another wire change and a decision
-> about whether that channel is used at all.
+> **`inbound_percept` → `injectEvent` is NOT a bypass — corrected 2026-08-25.**
+> An earlier note here called it the last one. Traced properly, it is not:
+> `injectEvent` writes a `senses.<domain>` ENTITY into the world, and
+> `exteroception` scans every entity outside `MIND_OWN_ENTITY_TYPES` and turns
+> appearances into percepts — so the percept is written by an ALLOWED writer, and
+> provenance is inferred there legitimately by the corollary-discharge matcher.
+>
+> A host putting something into the world and the mind noticing it through
+> exteroception is arguably the most honest shape available. Nothing to fix.
+>
+> Two true things about it worth recording instead: the channel has **no senders
+> anywhere** — not in this package, not in the backend, not in studio, only its
+> own test — and what it injects reaches the mind through the world rather than
+> through a sense door, which is a different route, not a missing one.
 
 ### P4 — Delete what the doors subsumed — ✅ **SHIPPED 2026-08-24**
 


### PR DESCRIPTION
P5's note called `inbound_percept` → `injectEvent` the last remaining bypass. Traced properly, it is not one.

`injectEvent` writes a `senses.<domain>` **entity into the world**. `exteroception` scans every entity outside `MIND_OWN_ENTITY_TYPES` and turns appearances into percepts — so the percept is written by an **allowed** writer, and provenance is inferred there legitimately by the corollary-discharge matcher.

A host putting something into the world and the mind noticing it through exteroception is arguably the most honest shape available. **Nothing to fix.**

## Why the note was wrong

What I had actually established was weaker than what I wrote: that the `senses.*` **bus event** consumers require a `.percept` suffix. That says nothing about the entity path, which is the path this channel actually uses.

Recording the correction rather than quietly dropping the claim, because the note as written would send the next reader to "fix" working code.

## What is true about it

- The channel has **no senders anywhere** — not in this package, not in the backend, not in studio; only its own test.
- What it injects reaches the mind **through the world** rather than through a sense door. A different route, not a missing one.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)