### PR TITLE
feat(executive): a commitment is not only a contact

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -12442,7 +12442,7 @@ ${options.activeConversations.map((c) => {
     What I worked out there: ${c.concluded.trim()}` : "";
       const promised = (c.promised ?? []).map(
         (p) => `
-    I said there that I would reach ${p.target}${p.gist ? ` \u2014 about: "${p.gist}"` : ""}, at tick ${p.tick}. Saying it in that thread did not send it.`
+    I said there that I would ${p.what}${p.gist ? ` \u2014 about: "${p.gist}"` : ""}, at tick ${p.tick}.` + (p.target ? " Saying it in that thread did not send it." : "")
       ).join("");
       return `${who}${concluded}${promised}`;
     }).join("\n")}
@@ -14097,8 +14097,13 @@ function validateFacetHandoff(payload) {
   if (!body || typeof body !== "object") return "payload.body is required";
   const kind = body.kind;
   if (kind === "escalation") return null;
-  if (kind === "undertaking")
-    return typeof body.target === "string" && body.target.trim().length > 0 ? null : "undertaking handoff requires a non-empty target";
+  if (kind === "undertaking") {
+    const what = body.what;
+    if (typeof what !== "string" || what.trim().length === 0)
+      return "undertaking handoff requires a non-empty what";
+    const target = body.target;
+    return target === void 0 || typeof target === "string" && target.trim().length > 0 ? null : "undertaking handoff target, when present, must be a non-empty string";
+  }
   return `unknown handoff kind: ${String(kind)}`;
 }
 function whereItHappened(h) {
@@ -15985,7 +15990,7 @@ var ExecutiveEngine = class extends AsyncEngine {
     if (payload.body.kind === "undertaking") {
       const body = payload.body;
       if (!payload.facetId) {
-        logger.warn(`[executive] undertaking toward "${body.target}" arrived with no facetId \u2014 nowhere to file it`);
+        logger.warn(`[executive] commitment "${body.what}" arrived with no facetId \u2014 nowhere to file it`);
         return;
       }
       const at = this._facetSubjects.get(payload.facetId) ?? {
@@ -15994,13 +15999,20 @@ var ExecutiveEngine = class extends AsyncEngine {
         tick
       };
       at.promised = [
-        // One entry per target: restating the same promise is the same promise.
-        ...(at.promised ?? []).filter((p) => p.target !== body.target),
-        { target: body.target, ...body.gist ? { gist: body.gist } : {}, tick }
+        // Deduped on WHAT was promised, falling back to the target when two
+        // wordings mean the same contact: restating a promise is the same
+        // promise, and the master does not need telling twice.
+        ...(at.promised ?? []).filter((p) => p.what !== body.what && !(body.target !== void 0 && p.target === body.target)),
+        {
+          what: body.what,
+          ...body.target ? { target: body.target } : {},
+          ...body.gist ? { gist: body.gist } : {},
+          tick
+        }
       ];
       this._facetSubjects.set(payload.facetId, at);
       logger.info(
-        `[executive] filed undertaking from ${from} \u2192 reach ${body.target} (it reads this at its next cycle; what to do about it is its own call)`
+        `[executive] filed commitment from ${from} \u2192 "${body.what}" (it reads this at its next cycle; what to do about it is its own call)`
       );
       return;
     }
@@ -21626,6 +21638,13 @@ var AuditionEngine = class extends BaseSenseEngine {
           );
           handoff({
             kind: "undertaking",
+            // The commitment in the mind's own words. A contact is one KIND of
+            // promise, not the only kind the tract can carry — see
+            // UndertakingHandoff. This producer only makes contact-shaped ones,
+            // because a facet declares an outward intent by naming a
+            // communicate action; anything else it means to follow through on
+            // goes through [GOALS_NEW], which the format already asks for.
+            what: `reach ${intent.target}`,
             target: intent.target,
             reasoning: intent.reasoning ?? "",
             ...intent.gist ? { gist: intent.gist } : {}

--- a/dist/surface/cli.js
+++ b/dist/surface/cli.js
@@ -14460,7 +14460,7 @@ ${options.activeConversations.map((c) => {
     What I worked out there: ${c.concluded.trim()}` : "";
       const promised = (c.promised ?? []).map(
         (p) => `
-    I said there that I would reach ${p.target}${p.gist ? ` \u2014 about: "${p.gist}"` : ""}, at tick ${p.tick}. Saying it in that thread did not send it.`
+    I said there that I would ${p.what}${p.gist ? ` \u2014 about: "${p.gist}"` : ""}, at tick ${p.tick}.` + (p.target ? " Saying it in that thread did not send it." : "")
       ).join("");
       return `${who}${concluded}${promised}`;
     }).join("\n")}
@@ -15319,8 +15319,13 @@ function validateFacetHandoff(payload) {
   if (!body || typeof body !== "object") return "payload.body is required";
   const kind = body.kind;
   if (kind === "escalation") return null;
-  if (kind === "undertaking")
-    return typeof body.target === "string" && body.target.trim().length > 0 ? null : "undertaking handoff requires a non-empty target";
+  if (kind === "undertaking") {
+    const what = body.what;
+    if (typeof what !== "string" || what.trim().length === 0)
+      return "undertaking handoff requires a non-empty what";
+    const target = body.target;
+    return target === void 0 || typeof target === "string" && target.trim().length > 0 ? null : "undertaking handoff target, when present, must be a non-empty string";
+  }
   return `unknown handoff kind: ${String(kind)}`;
 }
 function whereItHappened(h) {
@@ -17207,7 +17212,7 @@ var ExecutiveEngine = class extends AsyncEngine {
     if (payload.body.kind === "undertaking") {
       const body = payload.body;
       if (!payload.facetId) {
-        logger.warn(`[executive] undertaking toward "${body.target}" arrived with no facetId \u2014 nowhere to file it`);
+        logger.warn(`[executive] commitment "${body.what}" arrived with no facetId \u2014 nowhere to file it`);
         return;
       }
       const at = this._facetSubjects.get(payload.facetId) ?? {
@@ -17216,13 +17221,20 @@ var ExecutiveEngine = class extends AsyncEngine {
         tick
       };
       at.promised = [
-        // One entry per target: restating the same promise is the same promise.
-        ...(at.promised ?? []).filter((p) => p.target !== body.target),
-        { target: body.target, ...body.gist ? { gist: body.gist } : {}, tick }
+        // Deduped on WHAT was promised, falling back to the target when two
+        // wordings mean the same contact: restating a promise is the same
+        // promise, and the master does not need telling twice.
+        ...(at.promised ?? []).filter((p) => p.what !== body.what && !(body.target !== void 0 && p.target === body.target)),
+        {
+          what: body.what,
+          ...body.target ? { target: body.target } : {},
+          ...body.gist ? { gist: body.gist } : {},
+          tick
+        }
       ];
       this._facetSubjects.set(payload.facetId, at);
       logger.info(
-        `[executive] filed undertaking from ${from} \u2192 reach ${body.target} (it reads this at its next cycle; what to do about it is its own call)`
+        `[executive] filed commitment from ${from} \u2192 "${body.what}" (it reads this at its next cycle; what to do about it is its own call)`
       );
       return;
     }
@@ -22814,6 +22826,13 @@ var AuditionEngine = class extends BaseSenseEngine {
           );
           handoff({
             kind: "undertaking",
+            // The commitment in the mind's own words. A contact is one KIND of
+            // promise, not the only kind the tract can carry — see
+            // UndertakingHandoff. This producer only makes contact-shaped ones,
+            // because a facet declares an outward intent by naming a
+            // communicate action; anything else it means to follow through on
+            // goes through [GOALS_NEW], which the format already asks for.
+            what: `reach ${intent.target}`,
             target: intent.target,
             reasoning: intent.reasoning ?? "",
             ...intent.gist ? { gist: intent.gist } : {}

--- a/src/cognition/faculties/executive.engine/engine.ts
+++ b/src/cognition/faculties/executive.engine/engine.ts
@@ -231,7 +231,7 @@ export class ExecutiveEngine extends AsyncEngine implements CognitiveEngine {
     tick:       number
     concluded?: string
     /** Commitments the facet declared toward a THIRD party while attending here. */
-    promised?:  Array<{ target: string; gist?: string; tick: number }>
+    promised?:  Array<{ what: string; target?: string; gist?: string; tick: number }>
   }>()
 
   // ── Cognitive models ───────────────────────────────────────
@@ -1539,7 +1539,7 @@ export class ExecutiveEngine extends AsyncEngine implements CognitiveEngine {
       // rather than dropping it quietly, which is how a promise disappears with
       // nobody able to tell whether it was ever made.
       if( !payload.facetId ){
-        logger.warn(`[executive] undertaking toward "${ body.target }" arrived with no facetId — nowhere to file it`)
+        logger.warn(`[executive] commitment "${ body.what }" arrived with no facetId — nowhere to file it`)
         return
       }
       // Created if absent: a facet can hand something up before its first sync,
@@ -1550,13 +1550,18 @@ export class ExecutiveEngine extends AsyncEngine implements CognitiveEngine {
         tick,
       }
       at.promised = [
-        // One entry per target: restating the same promise is the same promise.
-        ...( at.promised ?? [] ).filter( p => p.target !== body.target ),
-        { target: body.target, ...( body.gist ? { gist: body.gist } : {} ), tick },
+        // Deduped on WHAT was promised, falling back to the target when two
+        // wordings mean the same contact: restating a promise is the same
+        // promise, and the master does not need telling twice.
+        ...( at.promised ?? [] ).filter( p =>
+          p.what !== body.what && !( body.target !== undefined && p.target === body.target ) ),
+        { what: body.what,
+          ...( body.target ? { target: body.target } : {} ),
+          ...( body.gist   ? { gist:   body.gist   } : {} ), tick },
       ]
       this._facetSubjects.set( payload.facetId, at )
       logger.info(
-        `[executive] filed undertaking from ${from} → reach ${ body.target } ` +
+        `[executive] filed commitment from ${from} → "${ body.what }" ` +
         `(it reads this at its next cycle; what to do about it is its own call)`
       )
       return

--- a/src/cognition/faculties/executive.engine/escalation.buffer.ts
+++ b/src/cognition/faculties/executive.engine/escalation.buffer.ts
@@ -43,14 +43,33 @@ export interface EscalationHandoff {
 }
 
 /**
- * An intention toward a THIRD party — "I'll reach out to FKEM now" — formed
- * while attending to something else. The facet never opens that channel itself,
- * so this is the only thing standing between having decided to make contact and
- * having made it.
+ * SOMETHING I SAID I WOULD DO, declared by the part of me that said it.
+ *
+ * It was `{ target, gist }` — a contact and nothing else — because the defect it
+ * was built for was capability-shaped rather than promise-shaped: a conversation
+ * facet can speak in its own thread but cannot open a channel to a third party,
+ * so the handoff carried the one act it structurally could not perform. Named
+ * "undertaking" and dressed in promise language, it read as a general commitment
+ * system with a strange restriction, and it was not one.
+ *
+ * `what` is the commitment in the mind's own words — "reach FKEM about the demo",
+ * "have the scoping doc by Friday", "look into the pricing". `target` is set only
+ * when it is toward someone the mind would have to REACH, which is still the case
+ * the tract exists for; a promise about work has no target and needs none.
+ *
+ * Note what this deliberately does NOT become: a task list. It is filed beside
+ * what the facet concluded and read once by the master, which may make a goal of
+ * it — the conversation format already says to raise [GOALS_NEW] for anything to
+ * follow through on, and goals are the thing that persists. This only ensures the
+ * seat that decides never learns of it too late to decide.
  */
 export interface UndertakingHandoff {
   kind:      'undertaking'
-  target:    string
+  /** What I said I would do, in my own words. */
+  what:      string
+  /** Who it is toward — only when keeping it means reaching someone. */
+  target?:   string
+  /** The words I had in mind for them, when I had any. */
   gist?:     string
   reasoning: string
 }
@@ -69,11 +88,18 @@ export function validateFacetHandoff( payload: unknown ): string | null {
   if( !body || typeof body !== 'object') return 'payload.body is required'
   const kind = ( body as { kind?: unknown } ).kind
   if( kind === 'escalation') return null
-  if( kind === 'undertaking')
-    return typeof ( body as { target?: unknown } ).target === 'string'
-        && ( body as { target: string } ).target.trim().length > 0
+  if( kind === 'undertaking'){
+    // `what` is the requirement now, not `target`. A promise about work has no
+    // one to reach and is still a promise; a promise with a target but nothing
+    // said is not one.
+    const what = ( body as { what?: unknown } ).what
+    if( typeof what !== 'string' || what.trim().length === 0 )
+      return 'undertaking handoff requires a non-empty what'
+    const target = ( body as { target?: unknown } ).target
+    return target === undefined || ( typeof target === 'string' && target.trim().length > 0 )
       ? null
-      : 'undertaking handoff requires a non-empty target'
+      : 'undertaking handoff target, when present, must be a non-empty string'
+  }
   return `unknown handoff kind: ${String( kind )}`
 }
 

--- a/src/cognition/faculties/executive.engine/prompt.factory.ts
+++ b/src/cognition/faculties/executive.engine/prompt.factory.ts
@@ -371,7 +371,7 @@ export interface PromptBuildOptions {
     /** What the mind worked out in that thread — its own reasoning, come back. */
     concluded?: string
     /** Commitments it made there toward someone NOT in the thread. */
-    promised?: Array<{ target: string; gist?: string; tick: number }>
+    promised?: Array<{ what: string; target?: string; gist?: string; tick: number }>
   }[]
 }
 
@@ -897,8 +897,12 @@ Dominance: ${context.affect.dominance.toFixed( 2 )}${context.affect.blends.lengt
           const who       = `- ${c.name ?? 'someone'} (id: ${c.entityId})`
           const concluded = c.concluded ? `\n    What I worked out there: ${c.concluded.trim()}` : ''
           const promised  = ( c.promised ?? [] ).map( p =>
-            `\n    I said there that I would reach ${p.target}${ p.gist ? ` — about: "${p.gist}"` : '' }`
-            + `, at tick ${p.tick}. Saying it in that thread did not send it.`
+            `\n    I said there that I would ${p.what}${ p.gist ? ` — about: "${p.gist}"` : '' }`
+            + `, at tick ${p.tick}.`
+            // Only a CONTACT can be mistaken for already done by having been
+            // said, which is the confusion this clause exists to break. A
+            // promise about work carries no such ambiguity and gets no lecture.
+            + ( p.target ? ' Saying it in that thread did not send it.' : '')
           ).join('')
           return `${who}${concluded}${promised}`
         } ).join('\n')}\nThese threads are already open — I am in them. Reaching out to one of these people again starts a second, parallel thread with them.`

--- a/src/cognition/senses/audition.engine/engine.ts
+++ b/src/cognition/senses/audition.engine/engine.ts
@@ -1312,6 +1312,13 @@ export class AuditionEngine extends BaseSenseEngine {
           )
           handoff({
             kind:      'undertaking',
+            // The commitment in the mind's own words. A contact is one KIND of
+            // promise, not the only kind the tract can carry — see
+            // UndertakingHandoff. This producer only makes contact-shaped ones,
+            // because a facet declares an outward intent by naming a
+            // communicate action; anything else it means to follow through on
+            // goes through [GOALS_NEW], which the format already asks for.
+            what:      `reach ${ intent.target }`,
             target:    intent.target,
             reasoning: intent.reasoning ?? '',
             ...( intent.gist ? { gist: intent.gist } : {} ),

--- a/tests/integration/facet.master.channel.test.ts
+++ b/tests/integration/facet.master.channel.test.ts
@@ -90,14 +90,14 @@ describe('facet → master channel survives the orchestrator\'s subscription', (
 
     publish( bus, 'executive.facet.handoff', {
       facetId: 'facet-1', subjectEntityId: 'discord:1019', threadId: 't', confidence: 0.85, tick: 13,
-      body: { kind: 'undertaking', reasoning: '', target: 'FKEM', gist: 'can you coordinate the demo meeting?' },
+      body: { kind: 'undertaking', reasoning: '', what: 'reach FKEM', target: 'FKEM', gist: 'can you coordinate the demo meeting?' },
     }, 'audition-engine')
 
     // Nothing queued as work for the master — an undertaking is not a task.
     expect( priv( engine )._escalations.drainToPercepts().percepts ).toHaveLength( 0 )
 
     const at = priv( engine )._facetSubjects.get('facet-1')!
-    expect( at.promised ).toEqual( [ { target: 'FKEM', gist: 'can you coordinate the demo meeting?', tick: 13 } ] )
+    expect( at.promised ).toEqual( [ { what: 'reach FKEM', target: 'FKEM', gist: 'can you coordinate the demo meeting?', tick: 13 } ] )
   } )
 
   it('files a promise even when it arrives before the first sync', () => {
@@ -107,11 +107,11 @@ describe('facet → master channel survives the orchestrator\'s subscription', (
 
     publish( bus, 'executive.facet.handoff', {
       facetId: 'facet-9', subjectEntityId: 'discord:1019', threadId: 't', confidence: 0.8, tick: 5,
-      body: { kind: 'undertaking', reasoning: '', target: 'FKEM' },
+      body: { kind: 'undertaking', reasoning: '', what: 'reach FKEM', target: 'FKEM' },
     }, 'audition-engine')
 
     expect( priv( engine )._facetSubjects.get('facet-9')?.promised )
-      .toEqual( [ { target: 'FKEM', tick: 5 } ] )
+      .toEqual( [ { what: 'reach FKEM', target: 'FKEM', tick: 5 } ] )
   } )
 
   it('learns who each facet is with AND what it worked out there', () => {
@@ -172,7 +172,8 @@ describe('and the master actually reads it', () => {
       activeConversations: [ {
         entityId: 'discord:1019', name: 'Fabrice', sinceTick: 12,
         concluded: 'He is asking for a demo and I think it is worth doing.',
-        promised:  [ { target: 'FKEM', gist: 'coordinate the demo meeting', tick: 13 } ],
+        promised:  [ { what: 'reach FKEM', target: 'FKEM', gist: 'coordinate the demo meeting', tick: 13 },
+                     { what: 'have the scoping doc ready by Friday', tick: 14 } ],
       } ],
     } as never )
 
@@ -180,6 +181,12 @@ describe('and the master actually reads it', () => {
     expect( prompt ).toContain('What I worked out there: He is asking for a demo')
     expect( prompt ).toContain('I said there that I would reach FKEM')
     expect( prompt ).toContain('Saying it in that thread did not send it.')
+
+    // A promise that is not a contact carries no such clause — only a CONTACT
+    // can be mistaken for already done by having been said.
+    expect( prompt ).toContain('I said there that I would have the scoping doc ready by Friday')
+    const workLine = prompt.split('\n').find( l => l.includes('scoping doc ready by Friday') )!
+    expect( workLine ).not.toContain('did not send it')
 
     // Stated as a fact and left there. What to do about it — keep it, drop it,
     // make a goal of it — is the mind's, and it has a faculty for that.

--- a/tests/unit/agency.outward-intent.test.ts
+++ b/tests/unit/agency.outward-intent.test.ts
@@ -233,7 +233,7 @@ describe('an undertaking rides the tract, and the harness is gone', () => {
     const buf = new EscalationBuffer()
     buf.push( {
       facetId: 'f-1', subjectEntityId: 'discord:1019376031150379101', threadId: 't', tick: 328,
-      body: { kind: 'undertaking', reasoning: '', target: 'FKEM', gist: 'coordinate the demo meeting' },
+      body: { kind: 'undertaking', reasoning: '', what: 'reach FKEM', target: 'FKEM', gist: 'coordinate the demo meeting' },
     } )
 
     // It never reaches the buffer at all — `_onFacetHandoff` files it with what
@@ -283,7 +283,7 @@ describe('executive.facet.handoff — one channel, any facet type', () => {
     const buf = new EscalationBuffer()
     buf.push( {
       subjectEntityId: 'discord:1019', subjectName: 'Fabrice', tick: 5,
-      body: { kind: 'undertaking', reasoning: '', target: 'FKEM' },
+      body: { kind: 'undertaking', reasoning: '', what: 'reach FKEM', target: 'FKEM' },
     } )
     expect( ( buf.drainToPercepts().percepts[0]!.metadata as Record<string, unknown> ).summary )
       .toMatch( /In my conversation with Fabrice/ )
@@ -303,15 +303,23 @@ describe('executive.facet.handoff — one channel, any facet type', () => {
 describe('validateFacetHandoff — the bus checks the shape, not each caller', () => {
   it('accepts both kinds', () => {
     expect( validateFacetHandoff({ body: { kind: 'escalation', reasoning: 'r' } }) ).toBeNull()
-    expect( validateFacetHandoff({ body: { kind: 'undertaking', target: 'FKEM' } }) ).toBeNull()
+    expect( validateFacetHandoff({ body: { kind: 'undertaking', what: 'reach FKEM', target: 'FKEM' } }) ).toBeNull()
   } )
 
-  it('rejects an undertaking with nobody to reach — it could never be discharged', () => {
-    // A target-less undertaking asserts "nothing has gone to them yet" forever:
-    // _reconcileUndertakings keys discharge on the target, so it can never be
-    // matched against a contact. Seven of these were found in one live snapshot.
-    expect( validateFacetHandoff({ body: { kind: 'undertaking' } }) ).toMatch( /target/ )
-    expect( validateFacetHandoff({ body: { kind: 'undertaking', target: '  ' } }) ).toMatch( /target/ )
+  it('accepts a commitment with nobody to reach — a promise about work is still a promise', () => {
+    // `target` used to be REQUIRED, because the discharge rule keyed on it and a
+    // target-less undertaking could never be matched against a contact. That
+    // rule is gone with the harness, and requiring a target made the tract only
+    // able to carry one kind of promise: "I'll have the doc by Friday" could not
+    // be declared at all.
+    expect( validateFacetHandoff({ body: { kind: 'undertaking', what: 'have the scoping doc by Friday' } }) ).toBeNull()
+  } )
+
+  it('rejects a commitment that says nothing — a target alone is not a promise', () => {
+    expect( validateFacetHandoff({ body: { kind: 'undertaking' } }) ).toMatch( /what/ )
+    expect( validateFacetHandoff({ body: { kind: 'undertaking', what: '  ', target: 'FKEM' } }) ).toMatch( /what/ )
+    // A present-but-empty target is still a mistake worth naming.
+    expect( validateFacetHandoff({ body: { kind: 'undertaking', what: 'reach them', target: '  ' } }) ).toMatch( /target/ )
   } )
 
   it('rejects a body it does not know, rather than dropping it silently', () => {

--- a/tests/unit/percept.writers.test.ts
+++ b/tests/unit/percept.writers.test.ts
@@ -118,7 +118,7 @@ describe('the retrofitted writers produce sweepable, tagged percepts', () => {
     const { EscalationBuffer } = await import('#faculties/executive.engine/escalation.buffer')
     const buf = new EscalationBuffer()
     buf.push( { facetId: 'f-1', subjectEntityId: 'ke:ada', subjectName: 'Ada', threadId: 't-1',
-                tick: 41, body: { kind: 'undertaking', target: 'ke:fkem',
+                tick: 41, body: { kind: 'undertaking', what: 'reach ke:fkem', target: 'ke:fkem',
                                   gist: 'the pricing question', reasoning: 'promised it' } } )
     buf.push( { facetId: 'f-2', tick: 42,
                 body: { kind: 'escalation', reasoning: 'the roadmap needs re-planning' } } )


### PR DESCRIPTION
`UndertakingHandoff` was `{ target, gist }` — a contact and nothing else — so *"I'll have the scoping doc by Friday"* could not be declared at all.

`what` is the promise in the mind's own words. `target` is set only when keeping it means **reaching** someone, which is still the case the tract exists for.

## Why it was contact-shaped

The defect it was built for was **capability-shaped, not promise-shaped**: a conversation facet can speak in its own thread but cannot open a channel to a third party, so the handoff carried the one act it structurally could not perform. Named "undertaking" and dressed in promise language, it read as a general commitment system with a strange restriction. It was a routing tract.

`target` could not have been made optional before now: the old discharge rule keyed on it, so a target-less undertaking could never be matched against a contact and would assert itself forever. That rule went with the harness.

## The render follows the shape

`I said there that I would <what>` — and *"Saying it in that thread did not send it"* is attached **only to a contact**. That ambiguity is one a contact has and a promise about work does not; adding it there would be a lecture.

Deduped on **what** was promised, falling back to the target so two wordings of the same contact do not both stand.

## Deliberately not a task list

It is filed beside what the facet concluded and read once. The conversation output format already tells the mind to raise `[GOALS_NEW]` for anything to follow through on, and a goal is the thing that persists. This only ensures the seat that decides never learns of it too late to decide.

## Verification

`tsc` clean, build clean, suite **1866 pass / 2 skip / 0 fail**. Mutation-verified: requiring a target again, and rendering `reach ${target}` again, each turn tests red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)